### PR TITLE
no underline needed in docstring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ balanced_wrapping = true
 # doc style
 [tool.pydocstyle]
 convention = "google"
-add_select = "D204,D215,D400,D401,D404,D406,D407,D408,D409,D413"
+add_select = "D204,D400,D401,D404,D406,D413"
 add_ignore = "D100,D104"
 
 # general linting


### PR DESCRIPTION
D215: Section underline is over-indented
D407: Missing dashed underline after section
D408: Section underline should be in the line following the section’s name
D409: Section underline should match the length of its name