### PR TITLE
no need for extra warning on line endings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ balanced_wrapping = true
 # doc style
 [tool.pydocstyle]
 convention = "google"
-add_select = "D204,D400,D401,D404,D406,D413"
+add_select = "D204,D400,D401,D404"
 add_ignore = "D100,D104"
 
 # general linting


### PR DESCRIPTION
D406: Section name should end with a newline
D413: Missing blank line after last section