### PR TITLE
disable pylint `no-member` error in favor of mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,8 @@ load-plugins = [
 ]
 [tool.pylint."messages control"]
 disable = [
-  "missing-module-docstring"
+  "missing-module-docstring",
+  "no-member"
 ]
 [tool.pylint.parameter_documentation]
 accept-no-param-doc = false


### PR DESCRIPTION
pylint
E1101: no-member

---

Minimum reproduction example:
```python
import torch
torch.rand(1)  # pylint error
torch.rnad(1)  # pylint and mypy error
```
Therefore, we can disable pylint check and rely on mypy.