### PR TITLE
disable pylint warning on magic value comparison

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ load-plugins = [
   "pylint.extensions.emptystring",
   "pylint.extensions.eq_without_hash",
   "pylint.extensions.for_any_all",
-  "pylint.extensions.magic_value",
   "pylint.extensions.mccabe",
   "pylint.extensions.no_self_use",
   "pylint.extensions.overlapping_exceptions",


### PR DESCRIPTION
pylint
R2004: magic-value-comparison

---

Reason to disable:
1. Sometimes it's simply expected. The author of the code should guarantee the use of magic values is indeed intended.
2. There are false negatives and this checker cannot guarantee the use of magic values is good even if enabled.

We disable this check for now until we find a good reason to re-enable it.