### PR TITLE
adjust `snake_case` to allow short names for vars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,10 @@ disable = [
   "missing-module-docstring",
   "no-member"
 ]
+[tool.pylint.basic]
+argument-rgx = '([^\W\dA-Z][^\WA-Z]*|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)$'
+attr-rgx = '([^\W\dA-Z][^\WA-Z]*|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)$'
+variable-rgx = '([^\W\dA-Z][^\WA-Z]*|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)$'
 [tool.pylint.parameter_documentation]
 accept-no-param-doc = false
 accept-no-raise-doc = false


### PR DESCRIPTION
affected: argument, attr, variable

---

By default, pylint only allows a name with at least length 3 for the `snake_case` style. However, based on context, short names can be reasonable.
Also, long names can still be bad and cannot be detected by the default rules.

Therefore, it's decided to remove the constraint on the length of var names, and the authors should guarantee good naming in their code.