### PR TITLE
disable mypy `no-untyped-call` error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ disallow_any_generics = true
 disallow_any_unimported = true
 disallow_incomplete_defs = true
 disallow_subclassing_any = true
-disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
 implicit_reexport = false


### PR DESCRIPTION
Reason:
1. Third-party libs can have untyped/incomplete `def`s. This will introduce too many errors.
2. All first-party code is guarded by `disallow_untyped_defs`, so there's no need to duplicate the error when called.