### PR TITLE
adjust pip caching in workflow and add mypy cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           python-version: '3.8'
           cache: 'pip'
+          cache-dependency-path: pyproject.toml
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -33,6 +34,7 @@ jobs:
         with:
           python-version: '3.8'
           cache: 'pip'
+          cache-dependency-path: pyproject.toml
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -50,6 +52,7 @@ jobs:
         with:
           python-version: '3.8'
           cache: 'pip'
+          cache-dependency-path: pyproject.toml
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -69,6 +72,7 @@ jobs:
         with:
           python-version: '3.8'
           cache: 'pip'
+          cache-dependency-path: pyproject.toml
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -89,6 +93,13 @@ jobs:
         with:
           python-version: '3.8'
           cache: 'pip'
+          cache-dependency-path: pyproject.toml
+      - name: Cache mypy_cache
+        uses: actions/cache@v3
+        with:
+          path: .mypy_cache
+          key: mypy_cache-${{ hashFiles('pyproject.toml') }}
+          restore-keys: mypy_cache-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
The pip cache now only checks only `pyproject.toml`, and is shared by all linting tasks. The tasks all depend on `cirkit[lint]`, and the editable-installed packages do not go into the cache dir. Thus the single cache key would work. (Although changing other configs will also make the cache obsolete unnecessarily.)

`.mypy_cache` is added to the caches using another cache action to save time on stdlibs and dependencies.