### PR TITLE
Revert "disable pylint warning on magic value comparison"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ load-plugins = [
   "pylint.extensions.emptystring",
   "pylint.extensions.eq_without_hash",
   "pylint.extensions.for_any_all",
+  "pylint.extensions.magic_value",
   "pylint.extensions.mccabe",
   "pylint.extensions.no_self_use",
   "pylint.extensions.overlapping_exceptions",


### PR DESCRIPTION
Reverts april-tools/cirkit#24

It seems for now that enforcing the use of enum classes/constant values is a good practice.