### PR TITLE
disable pylint `fixme` error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,8 @@ load-plugins = [
 [tool.pylint."messages control"]
 disable = [
   "missing-module-docstring",
-  "no-member"
+  "no-member",
+  "fixme"
 ]
 [tool.pylint.basic]
 argument-rgx = '([^\W\dA-Z][^\WA-Z]*|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)$'


### PR DESCRIPTION
Now we're in development. Comments like TODO or FIXME should be allowed even in the code merged to the `main` branch.