### PR TITLE
remove useless config of isort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ required-version = 23
 py_version = 39
 profile = "black"
 line_length = 100
-balanced_wrapping = true
 extra_standard_library = [  # we treat these as stdlib
   "typing_extensions"
 ]


### PR DESCRIPTION
it's overridden by black settings

`profile = "black"` include line wrapping config as "'black" style