### PR TITLE
allow redundant reexport in `__init__.py` files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,8 @@ disable = [
 argument-rgx = '([^\W\dA-Z][^\WA-Z]*|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)$'
 attr-rgx = '([^\W\dA-Z][^\WA-Z]*|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)$'
 variable-rgx = '([^\W\dA-Z][^\WA-Z]*|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)$'
+[tool.pylint.import]
+allow-reexport-from-package = true
 [tool.pylint.parameter_documentation]
 accept-no-param-doc = false
 accept-no-raise-doc = false


### PR DESCRIPTION
Motivation:
By default pylint complains about `useless-import-alias` with `import A as A`.
This setting is to allow `from . import A as A` style reexport in `__init__.py` files only.