### PR TITLE
disable pylint `duplicate-code`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ disable = [
   "missing-module-docstring",
   "no-member",
   "fixme",
+  "duplicate-code",
 ]
 [tool.pylint.basic]
 argument-rgx = '([^\W\dA-Z][^\WA-Z]*|_[^\WA-Z]*|__[^\WA-Z\d_][^\WA-Z]+__)$'


### PR DESCRIPTION
Motivation:
Inconsistent results observed with possible false negatives. By pylint-dev/pylint#1457, we cannot rely on pylint's detection before the bug fixed.

For now, we turn this off and rely on human to detect duplicate code.