### PR TITLE
Enable CI on push to `main` branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 jobs:
   tests:


### PR DESCRIPTION
Closes #51, closes #63 

CI checks now run on both PR open/sync and merge to `main` -- 1. to enable global caching (#51), and 2. to hint should non-synced PR break anything (#63).

Also, all linting jobs are merged into one workflow: based on previous runs, linting itself is fast -- faster than env setup. With them merged, we save total workflow time with no need to wait much longer.