### PR TITLE
Fix `pylint: disable` pragma

### DIFF
--- a/cirkit/layers/einsum/einsum.py
+++ b/cirkit/layers/einsum/einsum.py
@@ -73,7 +73,7 @@ class EinsumLayer(Layer):
     # TODO: find a better way to do this override
     # TODO: what about abstract?
     @abstractmethod
-    # pylint: disable=arguments-differ
+    # pylint: disable-next=arguments-differ
     def forward(self, log_left: Tensor, log_right: Tensor) -> Tensor:  # type: ignore[override]
         """Compute the main Einsum operation of the layer.
 

--- a/cirkit/layers/einsum/mixing.py
+++ b/cirkit/layers/einsum/mixing.py
@@ -93,7 +93,7 @@ class EinsumMixingLayer(Layer):
         return torch.einsum("bonc,onc->bon", x, self.param)
 
     # TODO: make forward return something
-    # pylint: disable=arguments-differ
+    # pylint: disable-next=arguments-differ
     def forward(self, log_input: Tensor) -> Tensor:  # type: ignore[override]
         """Do the forward.
 

--- a/cirkit/layers/exp_family/exp_family.py
+++ b/cirkit/layers/exp_family/exp_family.py
@@ -109,7 +109,7 @@ class ExpFamilyLayer(Layer):  # pylint: disable=too-many-instance-attributes
         """Reset parameters to default initialization: N(0, 1)."""
         nn.init.normal_(self.params)
 
-    # pylint: disable=arguments-differ
+    # pylint: disable-next=arguments-differ
     def forward(self, x: Tensor) -> Tensor:  # type: ignore[override]
         """Compute the factorized leaf densities. We are doing the computation \
             in the log-domain, so this is actually \

--- a/cirkit/layers/layer.py
+++ b/cirkit/layers/layer.py
@@ -61,7 +61,7 @@ class Layer(nn.Module, ABC):
         return super().__call__(*args, **kwargs)  # type: ignore[no-any-return,misc]
 
     @abstractmethod
-    # pylint: disable=missing-param-doc
+    # pylint: disable-next=missing-param-doc
     def forward(self, *args: Tensor, **kwargs: Tensor) -> Tensor:
         """Implement forward.
 

--- a/cirkit/models/einet.py
+++ b/cirkit/models/einet.py
@@ -86,7 +86,7 @@ class LowRankEiNet(nn.Module):
     """EiNet with low rank impl."""
 
     # TODO: why graph is not in args?
-    # pylint: disable=too-complex,too-many-locals,too-many-statements
+    # pylint: disable-next=too-complex,too-many-locals,too-many-statements
     def __init__(self, graph: RegionGraph, args: _Args) -> None:
         """Make an EinsumNetwork.
 
@@ -378,7 +378,7 @@ class LowRankEiNet(nn.Module):
     # TODO: and what's the meaning of this?
     # def backtrack(self, num_samples=1, class_idx=0, x=None, mode='sampling', **kwargs):
     # TODO: there's actually nothing to doc
-    # pylint: disable=missing-param-doc
+    # pylint: disable-next=missing-param-doc
     def backtrack(self, *_: Any, **__: Any) -> None:  # type: ignore[misc]
         """Raise an error.
 
@@ -387,6 +387,7 @@ class LowRankEiNet(nn.Module):
         """
         raise NotImplementedError
 
+    # pylint: disable-next=missing-param-doc
     def sample(  # type: ignore[misc]
         self, num_samples: int = 1, class_idx: int = 0, x: Optional[Tensor] = None, **_: Any
     ) -> None:
@@ -399,6 +400,7 @@ class LowRankEiNet(nn.Module):
         """
         self.backtrack(num_samples=num_samples, class_idx=class_idx, x=x, mode="sample")
 
+    # pylint: disable-next=missing-param-doc
     def mpe(  # type: ignore[misc]
         self, num_samples: int = 1, class_idx: int = 0, x: Optional[Tensor] = None, **_: Any
     ) -> None:


### PR DESCRIPTION
Correct `disable=` to `disable-next=` where appropriate.