### PR TITLE
Added reparametrizations

### DIFF
--- a/cirkit/layers/mixing.py
+++ b/cirkit/layers/mixing.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Callable, List
 
 import torch
 from torch import Tensor, nn
@@ -6,6 +6,7 @@ from torch import Tensor, nn
 from cirkit.layers.layer import Layer
 from cirkit.region_graph import RegionNode
 from cirkit.utils import log_func_exp
+from cirkit.utils.reparams import reparam_id
 
 # TODO: rework docstrings
 
@@ -51,16 +52,25 @@ class MixingLayer(Layer):
     """
 
     # TODO: num_output_units is num_input_units
-    def __init__(self, rg_nodes: List[RegionNode], num_output_units: int, max_components: int):
+    def __init__(
+        self,
+        rg_nodes: List[RegionNode],
+        num_output_units: int,
+        max_components: int,
+        *,
+        reparam: Callable[[torch.Tensor], torch.Tensor] = reparam_id,
+    ) -> None:
         """Init class.
 
         Args:
             rg_nodes (List[PartitionNode]): The region graph's partition node of the layer.
             num_output_units (int): The number of output units.
             max_components (int): Max number of mixing components.
+            reparam: The reparameterization function.
         """
         super().__init__()
         self.rg_nodes = rg_nodes
+        self.reparam = reparam
 
         # TODO: what need to be saved to self?
         self.num_output_units = num_output_units
@@ -79,7 +89,7 @@ class MixingLayer(Layer):
             self.params /= self.params.sum(dim=1, keepdim=True)  # type: ignore[misc]
 
     def _forward_linear(self, x: Tensor) -> Tensor:
-        return torch.einsum("fck,fckb->fkb", self.params, x)
+        return torch.einsum("fck,fckb->fkb", self.reparam(self.params), x)
 
     # TODO: make forward return something
     # pylint: disable-next=arguments-differ

--- a/cirkit/utils/reparams.py
+++ b/cirkit/utils/reparams.py
@@ -1,0 +1,79 @@
+import torch
+
+
+def reparam_id(p: torch.Tensor) -> torch.Tensor:
+    """No reparametrization.
+
+    This is an identity function on tensors.
+
+    Args:
+        p: The parameters tensor.
+
+    Returns:
+        torch.Tensor: No-op, p itself.
+    """
+    return p
+
+
+def reparam_exp(p: torch.Tensor) -> torch.Tensor:
+    """Reparametrize parameters via exponentiation.
+
+    Args:
+        p: The parameters tensor.
+
+    Returns:
+        torch.Tensor: The element-wise exponentiation of p.
+    """
+    return torch.exp(p)
+
+
+def reparam_square(p: torch.Tensor) -> torch.Tensor:
+    """Reparametrize parameters via squaring.
+
+    Args:
+        p: The parameters tensor.
+
+    Returns:
+        torch.Tensor: The element-wise squaring of p.
+    """
+    return torch.square(p)
+
+
+def reparam_softmax(p: torch.Tensor, dim: int = 0) -> torch.Tensor:
+    """Reparametrize parameters via softmax.
+
+    Args:
+        p: The parameters tensor.
+        dim: The dimension along which apply the softmax.
+
+    Returns:
+        torch.Tensor: The softmax of p along the given dimension.
+    """
+    return torch.softmax(p, dim=dim)
+
+
+def reparam_log_softmax(p: torch.Tensor, dim: int = 0) -> torch.Tensor:
+    """Reparametrize parameters via log-softmax.
+
+    Args:
+        p: The parameters tensor.
+        dim: The dimension along which apply the log-softmax.
+
+    Returns:
+        torch.Tensor: The log-softmax of p along the given dimension.
+    """
+    return torch.log_softmax(p, dim=dim)
+
+
+def reparam_positive(p: torch.Tensor, eps: float = 1e-15) -> torch.Tensor:
+    """Reparameterize parameters to be positive with a given threshold.
+
+    Args:
+        p: The parameters tensor.
+        eps: The minimum positive value.
+
+    Returns:
+        torch.Tensor: The element-wise clamping of p with eps as minimum value.
+    """
+    assert eps > 0.0, "The epsilon value should be positive"
+    return torch.clamp(p, min=eps)

--- a/tests/models/pcs/test_tensorized_pc.py
+++ b/tests/models/pcs/test_tensorized_pc.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-function-docstring
 # TODO: disable checking for docstrings for every test file in tests/
-
+import functools
 import itertools
 import math
 from typing import Callable, Dict, List, Optional, Tuple, Union
@@ -18,6 +18,13 @@ from cirkit.region_graph.poon_domingos import PoonDomingos
 from cirkit.region_graph.quad_tree import QuadTree
 from cirkit.region_graph.random_binary_tree import RandomBinaryTree
 from cirkit.utils import RandomCtx
+from cirkit.utils.reparams import (
+    reparam_exp,
+    reparam_id,
+    reparam_positive,
+    reparam_softmax,
+    reparam_square,
+)
 
 
 def _gen_rg_2x2() -> RegionGraph:  # pylint: disable=too-many-locals
@@ -156,7 +163,9 @@ def test_small_pc_partition_function() -> None:
 
 
 def _get_deep_pc(  # type: ignore[misc]
-    rg_cls: Callable[..., RegionGraph], kwargs: Dict[str, Union[int, bool, List[int]]]
+    rg_cls: Callable[..., RegionGraph],
+    kwargs: Dict[str, Union[int, bool, List[int]]],
+    reparam_func: Callable[[torch.Tensor], torch.Tensor] = reparam_id,
 ) -> TensorizedPC:
     # TODO: type of kwargs should be refined
     rg = rg_cls(**kwargs)
@@ -168,6 +177,7 @@ def _get_deep_pc(  # type: ignore[misc]
         efamily_kwargs={"num_categories": 2},  # type: ignore[misc]
         num_inner_units=16,
         num_input_units=16,
+        reparam=reparam_func,
     )
     return pc
 
@@ -204,7 +214,7 @@ def test_pc_marginalization(
     # Generate all possible combinations of 16 integers from the list of possible values
     possible_values = [0, 1]
     all_data = torch.tensor(
-        list(itertools.product(possible_values, repeat=pc.num_variables))  # type: ignore[misc]
+        list(itertools.product(possible_values, repeat=num_vars))  # type: ignore[misc]
     )
 
     # Instantiate the integral of the PC, i.e., computing the partition function
@@ -214,7 +224,6 @@ def test_pc_marginalization(
 
     # Compute outputs
     log_scores = pc(all_data)
-
     lls = log_scores - log_z
 
     # Check the partition function computation
@@ -233,3 +242,69 @@ def test_pc_marginalization(
     sum_lls = torch.logsumexp(lls.view(-1, 4), dim=1, keepdim=True)
     assert mar_lls.shape[0] == lls.shape[0] // 4 and len(mar_lls.shape) == len(lls.shape)
     assert torch.allclose(sum_lls, mar_lls, rtol=1e-6, atol=torch.finfo(torch.float32).eps)
+
+
+@pytest.mark.parametrize(  # type: ignore[misc]
+    "rg_cls,kwargs,reparam_name",
+    [
+        (rg_cls, kwargs, reparam_name)
+        for (rg_cls, kwargs) in (
+            (PoonDomingos, {"shape": [4, 4], "delta": 2}),
+            (QuadTree, {"width": 4, "height": 4, "struct_decomp": False}),
+            (RandomBinaryTree, {"num_vars": 16, "depth": 3, "num_repetitions": 2}),
+            (PoonDomingos, {"shape": [3, 3], "delta": 2}),
+            (QuadTree, {"width": 3, "height": 3, "struct_decomp": False}),
+            (QuadTree, {"width": 3, "height": 3, "struct_decomp": True}),
+            (RandomBinaryTree, {"num_vars": 9, "depth": 3, "num_repetitions": 2}),
+        )
+        for reparam_name in ("exp", "square", "softmax", "positive")
+    ],
+)
+@RandomCtx(42)
+def test_einet_nonneg_reparams(
+    rg_cls: Callable[..., RegionGraph],
+    kwargs: Dict[str, Union[int, bool, List[int]]],
+    reparam_name: str,
+) -> None:
+    """Tests multiple non-negative re-parametrizations on tensorized circuits.
+
+    Args:
+        rg_cls (Type[RegionGraph]): The class of RG to test.
+        kwargs (Dict[str, Union[int, bool, List[int]]]): The args for class to test.
+        reparam_name (str): The reparametrization function identifier.
+    """
+    if reparam_name == "exp":
+        reparam_func = reparam_exp
+    elif reparam_name == "square":
+        reparam_func = reparam_square
+    elif reparam_name == "softmax":
+        reparam_func = functools.partial(reparam_softmax, dim=-2)
+    elif reparam_name == "positive":
+        reparam_func = functools.partial(reparam_positive, eps=1e-7)
+    else:
+        assert False
+
+    pc = _get_deep_pc(rg_cls, kwargs, reparam_func=reparam_func)  # type: ignore[misc]
+    num_vars = pc.num_variables
+
+    # Generate all possible combinations of 16 integers from the list of possible values
+    possible_values = [0, 1]
+    all_data = torch.tensor(
+        list(itertools.product(possible_values, repeat=num_vars))  # type: ignore[misc]
+    )
+
+    # Instantiate the integral of the PC, i.e., computing the partition function
+    pc_pf = integrate(pc)
+    log_z = pc_pf()
+    assert log_z.shape == (1, 1)
+
+    # Compute outputs
+    log_scores = pc(all_data)
+
+    # Check the partition function computation
+    assert torch.isclose(log_z, torch.logsumexp(log_scores, dim=0, keepdim=True), atol=5e-7)
+
+    # The circuit should be already normalized,
+    #  if the re-parameterization is via softmax and using normalized input distributions
+    if reparam_name == "softmax":
+        assert torch.allclose(log_z, torch.zeros(()), atol=5e-7)

--- a/tests/utils/test_reparams.py
+++ b/tests/utils/test_reparams.py
@@ -1,0 +1,35 @@
+# pylint: disable=missing-function-docstring
+# TODO: disable checking for docstrings for every test file in tests/
+
+import torch
+
+from cirkit.utils import RandomCtx
+from cirkit.utils.reparams import (
+    reparam_exp,
+    reparam_id,
+    reparam_log_softmax,
+    reparam_positive,
+    reparam_softmax,
+    reparam_square,
+)
+
+
+@RandomCtx(42)
+def test_reparams() -> None:
+    p = torch.randn(10, 10)
+    assert torch.all(p == reparam_id(p))
+    assert torch.allclose(reparam_exp(p), torch.exp(p))
+    assert torch.allclose(reparam_square(p), torch.square(p))
+    assert torch.allclose(torch.sum(reparam_softmax(p, dim=0), dim=0), torch.ones(()))
+    assert torch.allclose(torch.sum(reparam_softmax(p, dim=-1), dim=-1), torch.ones(()))
+    assert torch.allclose(
+        torch.logsumexp(reparam_log_softmax(p, dim=0), dim=0),
+        torch.zeros(()),
+        atol=torch.finfo(torch.float32).eps,
+    )
+    assert torch.allclose(
+        torch.logsumexp(reparam_log_softmax(p, dim=-1), dim=-1),
+        torch.zeros(()),
+        atol=torch.finfo(torch.float32).eps,
+    )
+    assert torch.all(reparam_positive(p, eps=1e-5) >= 1e-5)


### PR DESCRIPTION
- Added re-parametrize functions, see https://github.com/april-tools/cirkit/blob/reparametrizations/cirkit/utils/reparams.py
- The ```reparam``` argument is a Callable from tensors to tensors that is passed as an argument when constructing the ```TensorizedPC```.

I was wondering which default initialization to use for layers though. At the moment parameters are initialized using a uniform distribution, which __perhaps__ does not plays well if using a ```exp``` or ```softmax``` re-parametrization.

Closes #80 #100.
