### PR TITLE
extract workflow scripts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,13 +33,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .[lint]
           bash ./benchmark/install_submodule.sh all
-      - name: Run Black
-        run: black --verbose --check --diff $(git ls-files "*.py")
-      - name: Run Isort
-        run: isort --verbose --check --diff $(git ls-files "*.py")
-      - name: Run Pydocstyle
-        run: pydocstyle --verbose $(git ls-files "*.py")
-      - name: Run Pylint
-        run: pylint --verbose --persistent=n $(git ls-files "*.py")
-      - name: Run Mypy
-        run: mypy $(git ls-files "*.py")
+      - name: Run linters
+        run: |
+          ./scripts/lint.sh --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,11 +24,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[test]
-      - name: Run PyTest
+      - name: Run Pytest with Coverage
         run: |
-          coverage run --source=cirkit -m pytest
-          coverage xml
-          coverage report -m
+          ./scripts/coverage.sh xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 lint = [
-  "black~=23.0",
+  "black[jupyter]~=23.0",
   "mypy==1.7.1",  # should be specific version for stable typing
   "pylint~=3.0.0",
   "pydocstyle[toml]~=6.3.0",
@@ -50,13 +50,19 @@ notebooks = [
 [project.urls]
 "Homepage" = "https://github.com/april-tools/cirkit"
 
+# unit test
 [tool.pytest.ini_options]
 pythonpath = "."
 testpaths = ["tests"]
 
+# code coverage
+[tool.coverage.run]
+branch = true
+source = ["cirkit"]
+
 [tool.coverage.report]
-# regex for exclusion
-exclude_also = [
+show_missing = true
+exclude_also = [  # regex for exclusion
   '@overload',
 ]
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Run coverage and print text report
+coverage run -m pytest
+coverage report
+
+# If required, generate report in additional format
+if [[ $# -ge 1 ]]; then
+    coverage "$1"
+    shift
+fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+verbose_diff="" # For black and isort
+verbose=""      # For pydocstyle and pylint
+# No verbost for mypy -- output too much
+if [ "$1" == "--verbose" ]; then
+    verbose_diff="--verbose --diff"
+    verbose="--verbose"
+    shift
+fi
+
+if [[ $# -gt 0 ]]; then
+    file_args=$@
+else
+    file_args=$(git ls-files "*.py")
+fi
+
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+echo -e "${CYAN}Running Black...${NC}"
+black $verbose_diff --check $file_args
+echo
+echo -e "${CYAN}Running Isort...${NC}"
+isort $verbose_diff --check $file_args
+echo
+echo -e "${CYAN}Running Pydocstyle...${NC}"
+pydocstyle $verbose $file_args
+echo
+echo -e "${CYAN}Running Pylint...${NC}"
+pylint $verbose --persistent=n $file_args
+echo
+echo -e "${CYAN}Running Mypy...${NC}"
+mypy $file_args


### PR DESCRIPTION
The commands to run linting and testing are originally part of the github workflow file and cannot be run directly.

Now we extract them into separate script files so that it's easy to locally run the linting/testing with one line.

To reduce repetition, the workflows now invoke the scripts.