### PR TITLE
Different scope product (decrepit)

### DIFF
--- a/cirkit/new/__init__.py
+++ b/cirkit/new/__init__.py
@@ -26,4 +26,23 @@ def set_layer_comp_space(comp_space: Union[Type[utils.ComputationSapce], str]) -
     layers.Layer.comp_space = comp_space
 
 
+def set_reparam_comp_space(comp_space: Union[Type[utils.ComputationSapce], str]) -> None:
+    """Set the global computational space for reparams.
+
+    Args:
+        comp_space (Union[Type[utils.ComputationSapce], str]): The computational space to use, can \
+            be speficied by either the class or the name.
+    """
+    if isinstance(comp_space, str):
+        comp_space = utils.ComputationSapce.get_comp_space_by_name(comp_space)
+
+    # CAST: __final__ is not part of standard data model.
+    assert cast(
+        bool, getattr(comp_space, "__final__", False)
+    ), "A usable ComputationSapce must be final."
+
+    reparams.Reparameterization.comp_space = comp_space
+
+
 set_layer_comp_space(utils.LogSpace)
+set_reparam_comp_space(utils.LogSpace)

--- a/cirkit/new/model/functional.py
+++ b/cirkit/new/model/functional.py
@@ -38,3 +38,20 @@ def differentiate(self: "TensorizedCircuit", *, order: int = 1) -> "TensorizedCi
         TensorizedCircuit: The circuit giving the (total) differential.
     """
     return self.__class__(self.symb_circuit.differentiate(order=order))
+
+
+def product(
+    self: "TensorizedCircuit", other: "TensorizedCircuit", *, scope: Optional[Iterable[int]] = None
+) -> "TensorizedCircuit":
+    """Perform product between two circuits over the given scope.
+
+    Args:
+        self (TensorizedCircuit): The first circuit to perform product.
+        other (TensorizedCircuit): The second circuit to perrform product.
+        scope (Optional[Iterable[int]], optional): The scope to perform product with, or None for \
+            the union of scope of the two circuits. Defaults to None.
+
+    Returns:
+        SymbolicTensorizedCircuit: The circuit product.
+    """
+    return self.__class__(self.symb_circuit.product(other.symb_circuit, scope=scope))

--- a/cirkit/new/model/tensorized_circuit.py
+++ b/cirkit/new/model/tensorized_circuit.py
@@ -172,3 +172,5 @@ class TensorizedCircuit(nn.Module):
     # NOTE: partialmethod is not suitable here as it does not have __call__ but __get__.
     grad_circuit = cached_property(functools.partial(differentiate, order=1))
     """The circuit calculating the gradient."""
+
+    product = TCF.product

--- a/cirkit/new/reparams/__init__.py
+++ b/cirkit/new/reparams/__init__.py
@@ -1,4 +1,7 @@
 from .binary import BinaryReparam as BinaryReparam
+from .binary import CategoricalProductReparam as CategoricalProductReparam
+from .binary import EFNormalProductReparam as EFNormalProductReparam
+from .binary import InnerLayerProductReparam as InnerLayerProductReparam
 from .composed import ComposedReparam as ComposedReparam
 from .leaf import LeafReparam as LeafReparam
 from .normalized import LogSoftmaxReparam as LogSoftmaxReparam

--- a/cirkit/new/reparams/binary.py
+++ b/cirkit/new/reparams/binary.py
@@ -1,9 +1,15 @@
+# pylint: skip-file
+# type: ignore
 from typing import Callable, Optional, Tuple, Union
 
+import torch
 from torch import Tensor
+from torch.nn import functional as F
 
 from cirkit.new.reparams.composed import ComposedReparam
+from cirkit.new.reparams.normalized import LogSoftmaxReparam, SoftmaxReparam
 from cirkit.new.reparams.reparam import Reparameterization
+from cirkit.new.utils import flatten_dims, unflatten_dims
 
 
 class BinaryReparam(ComposedReparam[Tensor, Tensor]):
@@ -34,7 +40,152 @@ class BinaryReparam(ComposedReparam[Tensor, Tensor]):
                 directly pass through if no inv_func provided. Defaults to None.
         """
         # pylint: enable=line-too-long
+
+        self.norm_func: Callable
+
+        # TODO: refactor
+        self.norm_func = (
+            reparam1.norm_func
+            if isinstance(reparam1, BinaryReparam)
+            else reparam2.norm_func
+            if isinstance(reparam2, BinaryReparam)
+            else torch.softmax
+            if (
+                isinstance(reparam1, SoftmaxReparam)
+                or (isinstance(reparam1, type) and issubclass(reparam1, SoftmaxReparam))
+                or isinstance(reparam2, SoftmaxReparam)
+                or (isinstance(reparam2, type) and issubclass(reparam2, SoftmaxReparam))
+            )
+            else torch.log_softmax
+            if (
+                isinstance(reparam1, LogSoftmaxReparam)
+                or (isinstance(reparam1, type) and issubclass(reparam1, LogSoftmaxReparam))
+                or isinstance(reparam2, LogSoftmaxReparam)
+                or (isinstance(reparam2, type) and issubclass(reparam2, LogSoftmaxReparam))
+            )
+            else None
+        )
+
         super().__init__(reparam1, reparam2, func=func, inv_func=inv_func)
 
 
-# TODO: circuit product
+class InnerLayerProductReparam(BinaryReparam):
+    """reparameterization for the product of inner layers of the circuit."""
+
+    def __init__(
+        self,
+        reparam1: Reparameterization,
+        reparam2: Reparameterization,
+        /,
+    ) -> None:
+        # DISABLE: This long line is unavoidable for Args doc.
+        """Init class.
+
+        Args:
+            reparam1 (Optional[Reparameterization], optional): The input reparameterization to be \
+                composed. If None, a LeafReparam will be constructed in its place. Defaults to None.
+            reparam2 (Optional[Reparameterization], optional): The input reparameterization to be \
+                composed. If None, a LeafReparam will be constructed in its place. Defaults to None.
+        """
+
+        super().__init__(reparam1, reparam2, func=self._func, inv_func=None)  # type: ignore[arg-type]
+
+    def _func(self, param1: Tensor, param2: Tensor) -> Tensor:
+        # Sum layer parameters: (K_out, 1, K_in, 1)
+        # Tucker layer parameters: (K_out, 1, K_in, 1, K_in, 1)
+        reshaped_param1_shape = [d for dim in zip(param1.shape, (1,) * param2.ndim) for d in dim]
+        # Sum layer parameters: (1, K_out, 1, K_in)
+        # Tucker layer parameters: (1, K_out, 1, K_in, 1, K_in)
+        reshaped_param2_shape = [d for dim in zip((1,) * param1.ndim, param2.shape) for d in dim]
+
+        # Sum layer parameters: (K_out1*K_out2, K_in1*K_in2)
+        # Tucker layer parameters: (K_out1*K_out2, K_in1*K_in2, K_in1*K_in2)
+        output_param_shape = tuple(d1 * d2 for d1, d2 in zip(param1.shape, param2.shape))
+
+        reshaped_param1 = param1.reshape(reshaped_param1_shape)
+        reshaped_param2 = param2.reshape(reshaped_param2_shape)
+
+        kron_param = self.comp_space.mul(reshaped_param1, reshaped_param2)
+        output_param = kron_param.reshape(output_param_shape)
+
+        if self.norm_func is not None:
+            output_param = unflatten_dims(
+                self.norm_func(flatten_dims(output_param, dims=self.dims), dim=self.dims[0]),
+                dims=self.dims,
+                shape=output_param.shape,
+            )
+            # TODO: need nan_to_num?
+
+        return output_param
+
+
+class CategoricalProductReparam(BinaryReparam):
+    """reparameterization for the product of categorical input layers."""
+
+    def __init__(
+        self,
+        reparam1: Reparameterization,
+        reparam2: Reparameterization,
+        /,
+    ) -> None:
+        # DISABLE: This long line is unavoidable for Args doc.
+        """Init class.
+
+        Args:
+            reparam1 (Optional[Reparameterization], optional): The input reparameterization to be \
+                composed. If None, a LeafReparam will be constructed in its place. Defaults to None.
+            reparam2 (Optional[Reparameterization], optional): The input reparameterization to be \
+                composed. If None, a LeafReparam will be constructed in its place. Defaults to None.
+        """
+
+        super().__init__(reparam1, reparam2, func=self._func, inv_func=None)  # type: ignore[arg-type]
+
+    def _func(self, param1: Tensor, param2: Tensor) -> Tensor:
+        # (arity, K_out_1, 1, K_in, cat)
+        reshaped_param1 = param1.unsqueeze(2)
+        # (arity, 1, K_out_2, K_in, cat)
+        reshaped_param2 = param2.unsqueeze(1)
+        # (arity, K_out_1*K_out_2, K_in, cat)
+        output_param = self.comp_space.mul(reshaped_param1, reshaped_param2).view(
+            param1.shape[0], -1, param1.shape[2], param1.shape[3]
+        )
+
+        if self.norm_func is not None:
+            assert len(self.dims) == 1
+            output_param = self.norm_func(output_param, dim=self.dims[0])
+            # TODO: need nan_to_num?
+        return output_param
+
+
+class EFNormalProductReparam(BinaryReparam):
+    """reparameterization for the product of exponential family normal input layers."""
+
+    def __init__(
+        self,
+        reparam1: Reparameterization,
+        reparam2: Reparameterization,
+        /,
+    ) -> None:
+        # DISABLE: This long line is unavoidable for Args doc.
+        """Init class.
+
+        Args:
+            reparam1 (Optional[Reparameterization], optional): The input reparameterization to be \
+                composed. If None, a LeafReparam will be constructed in its place. Defaults to None.
+            reparam2 (Optional[Reparameterization], optional): The input reparameterization to be \
+                composed. If None, a LeafReparam will be constructed in its place. Defaults to None.
+        """
+
+        super().__init__(reparam1, reparam2, func=self._func, inv_func=None)  # type: ignore[arg-type]
+
+    def _func(self, param1: Tensor, param2: Tensor) -> Tensor:
+        # (arity, K_out_1, 1, 2, K_in)
+        reshaped_param1 = param1.unsqueeze(2)
+        # (arity, 1, K_out_2, 2, K_in)
+        reshaped_param2 = param2.unsqueeze(1)
+        # (arity, K_out_1*K_out_2, 2, K_in)
+        output_param = self.comp_space.sum(
+            torch.add, reshaped_param1, reshaped_param2, dim=(1, 2), keepdim=True
+        ).view(param1.shape[0], -1, param1.shape[2], param1.shape[3])
+
+        return output_param

--- a/cirkit/new/reparams/composed.py
+++ b/cirkit/new/reparams/composed.py
@@ -86,7 +86,7 @@ class ComposedReparam(Reparameterization, Generic[Unpack[Ts]]):
         """
         if not super().materialize(shape, dim=dim):
             return False
-
+        # TODO: modify reparam.shape?
         for reparam in self.reparams:
             if not reparam.is_materialized:
                 # NOTE: Passing shape to all children reparams may not be always wanted. In that
@@ -94,7 +94,8 @@ class ComposedReparam(Reparameterization, Generic[Unpack[Ts]]):
                 #       is skipped by the above if.
                 reparam.materialize(shape, dim=dim)
 
-        assert self().shape == self.shape, "The actual shape does not match the given one."
+            assert reparam.shape == self.shape, "The actual shape does not match the given one."
+
         return True
 
     def initialize(self, initializer_: Callable[[Tensor], Tensor]) -> None:

--- a/cirkit/new/reparams/reparam.py
+++ b/cirkit/new/reparams/reparam.py
@@ -1,8 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import Callable, Sequence, Tuple, Union
+from typing import Callable, ClassVar, Sequence, Tuple, Type, Union
 
 import torch
 from torch import Tensor, nn
+
+from cirkit.new.utils import ComputationSapce
 
 
 class Reparameterization(nn.Module, ABC):
@@ -22,6 +24,9 @@ class Reparameterization(nn.Module, ABC):
 
     shape: Tuple[int, ...]
     """The shape of the output parameter."""
+
+    comp_space: ClassVar[Type[ComputationSapce]]
+    """The computational space for reparameterization"""
 
     @property
     @abstractmethod

--- a/cirkit/new/symbolic/symbolic_circuit.py
+++ b/cirkit/new/symbolic/symbolic_circuit.py
@@ -276,6 +276,7 @@ class SymbolicTensorizedCircuit:  # pylint: disable=too-many-instance-attributes
 
     integrate = STCF.integrate
     differentiate = STCF.differentiate
+    product = STCF.product
 
     ####################################    (De)Serialization    ###################################
     # TODO: impl? or just save RG and kwargs of SymbC?


### PR DESCRIPTION
Discussion: 

Integral and differential on circuit product simply use the original code

Always normalize the parameters after product / normalize given a command? 

Partition function for EF normal: closed-form expression is hard to extend to multiple product, discard it? 

Scope renaming / assigning scope? 

Different scope product still have some unfinished edge cases

Naming: binaryReparam -> productReparam?

