### PR TITLE
refactored product to get_product

### DIFF
--- a/cirkit/new/layers/inner/inner.py
+++ b/cirkit/new/layers/inner/inner.py
@@ -56,18 +56,16 @@ class InnerLayer(Layer):
         self_symb_cfg: SymbLayerCfg[Self],
         other_symb_cfg: SymbLayerCfg[Self],
     ) -> SymbLayerCfg[Self]:
-        """Get the symbolic config to construct the product of this inner layer \
-            with the other inner layer.
-        
-        Pre-requisite:
-            The two inner layers for product must be of the same layer class. \
-                This means that the product must be performed between two \
-                circuits with the same region graph.
+        """Get the symbolic config to construct the product of this inner layer with the other \
+        inner layer.
+
+        The two inner layers for product must be of the same layer class. This means that the \
+        product must be performed between two circuits with the same region graph.
 
         Args:
             self_symb_cfg (SymbLayerCfg[Self]): The symbolic config for this layer.
             other_symb_cfg (SymbLayerCfg[Self]): The symbolic config for the other layer.
 
         Returns:
-            SymbLayerCfg[Self]: The symbolic config for the product of two inner layers.
+            SymbLayerCfg[Self]: The symbolic config for the product of the two inner layers.
         """

--- a/cirkit/new/layers/inner/product/hadamard.py
+++ b/cirkit/new/layers/inner/product/hadamard.py
@@ -68,22 +68,21 @@ class HadamardLayer(ProductLayer):
         self_symb_cfg: SymbLayerCfg[Self],
         other_symb_cfg: SymbLayerCfg[Self],
     ) -> SymbLayerCfg[Self]:
-        """Get the symbolic config to construct the product of this Hadamard layer \
-            with the other Hadamard layer.
+        """Get the symbolic config to construct the product of this Hadamard layer with the other \
+        Hadamard layer.
 
-        The layer config is unchanged, as (a_1 ⊙ a_2 ⊙ ... ⊙ a_n) ⊗ (b_1 ⊙ b_2 ⊙ ... ⊙ b_n) = \
-            (a_1 ⊗ b_1) ⊙ (a_2 ⊗ b_2) ⊙ ... ⊙ (a_n ⊗ b_n).
+        The two inner layers for product must be of the same layer class. This means that the \
+        product must be performed between two circuits with the same region graph.
 
-        Pre-requisite:
-            The two layers for product must be of the same layer class (HadamardLayer). \
-                This means that the product must be performed between two \
-                circuits with the same region graph.
+        The layer config is unchanged, because:
+            (a_1 ⊙ a_2 ⊙ ... ⊙ a_n) ⊗ (b_1 ⊙ b_2 ⊙ ... ⊙ b_n)
+            = (a_1 ⊗ b_1) ⊙ (a_2 ⊗ b_2) ⊙ ... ⊙ (a_n ⊗ b_n).
 
         Args:
             self_symb_cfg (SymbLayerCfg[Self]): The symbolic config for this layer.
             other_symb_cfg (SymbLayerCfg[Self]): The symbolic config for the other layer.
 
         Returns:
-            SymbLayerCfg[Self]: The symbolic config for the product of two Hadamard layers.
+            SymbLayerCfg[Self]: The symbolic config for the product of the two Hadamard layers.
         """
         return self_symb_cfg

--- a/cirkit/new/layers/inner/product/kronecker.py
+++ b/cirkit/new/layers/inner/product/kronecker.py
@@ -73,21 +73,23 @@ class KroneckerLayer(ProductLayer):
         self_symb_cfg: SymbLayerCfg[Self],
         other_symb_cfg: SymbLayerCfg[Self],
     ) -> SymbLayerCfg[Self]:
-        """Get the symbolic config to construct the product of this Kronecker layer \
-            with the other Kronecker layer.
-            
-        The new layer config of this Kronecker layer is unchanged, as \
-            (a_1 ⊗ a_2) ⊗ (b_1 ⊗ b_2) = PermuteMatrix((a_1 ⊗ b_1) ⊗ (a_2 ⊗ b_2)). \
-            Where the PermuteMatrix is treated as a parent sum layer.
-        
-        Pre-requisite:
-            - The arity of both layers must be 2.
-            - The two layers for product must be of the same layer class (KroneckerLayer). \
-                This means that the product must be performed between two \
-                circuits with the same region graph.
+        """Get the symbolic config to construct the product of this Kronecker layer with the other \
+        Kronecker layer.
+
+        The two inner layers for product must be of the same layer class. This means that the \
+        product must be performed between two circuits with the same region graph.
+
+        TODO: we need permutation: \
+            (a_1 ⊗ a_2) ⊗ (b_1 ⊗ b_2) = PermuteMatrix((a_1 ⊗ b_1) ⊗ (a_2 ⊗ b_2)).
 
         Args:
             self_symb_cfg (SymbLayerCfg[Self]): The symbolic config for this layer.
             other_symb_cfg (SymbLayerCfg[Self]): The symbolic config for the other layer.
+
+        Raises:
+            NotImplementedError: When "not-yet-implemented feature" is invoked.
+
+        Returns:
+            SymbLayerCfg[Self]: The symbolic config for the product of the two Kronecker layers.
         """
         raise NotImplementedError("Product between two kroneker layers is not implemented yet.")

--- a/cirkit/new/layers/inner/sum/dense.py
+++ b/cirkit/new/layers/inner/sum/dense.py
@@ -68,6 +68,5 @@ class DenseLayer(SumLayer):
         x = x.squeeze(dim=0)  # shape (H=1, *B, K) -> (*B, K).
         return self.comp_space.sum(self._forward_linear, x, dim=-1, keepdim=True)  # shape (*B, K).
 
-
-# NOTE: DenseLayer class have get_product() function, it directly use the get_product() function
-#       in base class SumLayer in sum.py.
+    # NOTE: get_product is inherited from SumLayer. The product between DesnLayer leads to the
+    #       Kronecker of the param.

--- a/cirkit/new/layers/inner/sum/mixing.py
+++ b/cirkit/new/layers/inner/sum/mixing.py
@@ -76,6 +76,5 @@ class MixingLayer(SumLayer):
             self._forward_linear, x, dim=0, keepdim=False
         )  # shape (H, *B, K) -> (*B, K).
 
-
-# NOTE: DenseLayer class have get_product() function, it directly use the get_product() function
-#       in base class SumLayer in sum.py.
+    # NOTE: get_product is inherited from SumLayer. The product between MixingLayer leads to the
+    #       Kronecker of the param, with the arity expanded to the product of arities.

--- a/cirkit/new/layers/inner/sum/sum.py
+++ b/cirkit/new/layers/inner/sum/sum.py
@@ -5,8 +5,7 @@ import torch
 from torch import nn
 
 from cirkit.new.layers.inner.inner import InnerLayer
-from cirkit.new.reparams import Reparameterization
-from cirkit.new.reparams.binary import KroneckerReparam
+from cirkit.new.reparams import KroneckerReparam, Reparameterization
 from cirkit.new.utils.type_aliases import SymbLayerCfg
 
 
@@ -29,23 +28,21 @@ class SumLayer(InnerLayer):
         self_symb_cfg: SymbLayerCfg[Self],
         other_symb_cfg: SymbLayerCfg[Self],
     ) -> SymbLayerCfg[Self]:
-        """Get the symbolic config to construct the product of this layer with the other layer, \
-            construct a new layer config with parameter (param_self ⊗ param_other).
-        
-        Pre-requisite:
-            - This function is ONLY USED for certain sub-classes of SumLayer: DenseLayer, CPLayer, \
-                and TuckerLayer. Sub-classes that does not follow this construction \
-                (e.g. MixingLayer) would need to override this function.
-            - The two layers for product must both be the same layer class.
-                This means that the product must be performed between two \
-                circuits with the same region graph.
+        """Get the symbolic config to construct the product of this sum layer with the other sum \
+        layer.
+
+        The two inner layers for product must be of the same layer class. This means that the \
+        product must be performed between two circuits with the same region graph.
+
+        This will construct a new layer config with param = param_self ⊗ param_other. This \
+        applies to all sum layers and sum-product layers. See each layer for details.
 
         Args:
             self_symb_cfg (SymbLayerCfg[Self]): The symbolic config for this layer.
             other_symb_cfg (SymbLayerCfg[Self]): The symbolic config for the other layer.
 
         Returns:
-            SymbLayerCfg[Self]: The symbolic config for the product of two sum-product layers.
+            SymbLayerCfg[Self]: The symbolic config for the product of the two sum layers.
         """
         assert (
             self_symb_cfg.layer_cls == other_symb_cfg.layer_cls

--- a/cirkit/new/layers/inner/sum_product/cp.py
+++ b/cirkit/new/layers/inner/sum_product/cp.py
@@ -76,8 +76,8 @@ class CPLayer(SumProductLayer):
         # shape (H, *B, K) -> (*B, K) -> (H, *B, K) -> (*B, K).
         return self.sum(self.prod(x).unsqueeze(dim=0))
 
+    # NOTE: get_product is inherited from SumLayer. The product between CPLayer leads to the
+    #       Kronecker of the param, just like DenseLayer.
 
-# NOTE: CPLayer class have get_product() function, it directly use the get_product() function
-#       in base class SumLayer in sum.py.
 
 # TODO: Uncollapsed?

--- a/cirkit/new/layers/inner/sum_product/tucker.py
+++ b/cirkit/new/layers/inner/sum_product/tucker.py
@@ -73,6 +73,6 @@ class TuckerLayer(SumProductLayer):
         """
         return self.comp_space.sum(self._forward_linear, x[0], x[1], dim=-1, keepdim=True)
 
-
-# NOTE: CPLayer class have get_product() function, it directly use the get_product() function
-#       in base class SumLayer in sum.py.
+    # NOTE: get_product is inherited from SumLayer. The product between TuckerLayer leads to the
+    #       Kronecker of the param. For the internal Kronecker, the arity is still 2, with each \
+    #       input mapped to the corresponding Kronecker'ed param axis.

--- a/cirkit/new/layers/input/constant.py
+++ b/cirkit/new/layers/input/constant.py
@@ -124,24 +124,21 @@ class ConstantLayer(InputLayer):
         self_symb_cfg: SymbLayerCfg[Self],
         other_symb_cfg: SymbLayerCfg[InputLayer],
     ) -> SymbLayerCfg[InputLayer]:
-        """Get the symbolic config to construct the product of this input layer \
-            with the other input layer.
-        
-        Cases:
-            - Product with ConstantLayer: c*c.
-            - Product with class in ExpFamilyLayer: c*f(x).
-            - Product with and DiffEFLayer: c*f'(x). 
-        
+        """Get the symbolic config to construct the product of this input layer with the other \
+        input layer.
+
+        TODO: scaling of other layers.
+
         Args:
             self_symb_cfg (SymbLayerCfg[Self]): The symbolic config for this layer.
-            other_symb_cfg (SymbLayerCfg[InputLayer]): The symbolic config for the other layer \
+            other_symb_cfg (SymbLayerCfg[InputLayer]): The symbolic config for the other layer, \
                 must be of InputLayer.
 
         Raises:
             NotImplementedError: When "not-yet-implemented feature" is invoked.
 
         Returns:
-            SymbLayerCfg[InputLayer]: The symbolic config for the product of two input layers.
+            SymbLayerCfg[InputLayer]: The symbolic config for the product of the two input layers.
         """
         if issubclass(other_symb_cfg.layer_cls, ConstantLayer):
             # IGNORE: Unavoidable for kwargs.
@@ -152,6 +149,7 @@ class ConstantLayer(InputLayer):
                     * other_symb_cfg.layer_kwargs["const_value"]  # type: ignore[misc]
                 },
             )
+
         raise NotImplementedError(
             "Product for constant input layer and other input layers not implemented."
         )

--- a/cirkit/new/layers/input/exp_family/diff_ef.py
+++ b/cirkit/new/layers/input/exp_family/diff_ef.py
@@ -162,23 +162,23 @@ class DiffEFLayer(InputLayer):
         self_symb_cfg: SymbLayerCfg[Self],
         other_symb_cfg: SymbLayerCfg[InputLayer],
     ) -> SymbLayerCfg[InputLayer]:
-        """Get the symbolic config to construct the product of this input layer \
-            with the other input layer.
-        
-        Cases:
-            - Product with DiffEFLayer: f_1'(x)*f_2'(x). 
+        """Get the symbolic config to construct the product of this input layer with the other \
+        input layer.
+
+        TODO: Cases:
+            - Product with DiffEFLayer: f_1'(x)*f_2'(x).
             - Product with class in ExpFamilyLayer: f_1'(x)*f_2(x).
             - Product with ConstantLayer: f'(x)*c.
-        
+
         Args:
             self_symb_cfg (SymbLayerCfg[Self]): The symbolic config for this layer.
-            other_symb_cfg (SymbLayerCfg[InputLayer]): The symbolic config for the other layer \
+            other_symb_cfg (SymbLayerCfg[InputLayer]): The symbolic config for the other layer, \
                 must be of InputLayer.
 
         Raises:
             NotImplementedError: When "not-yet-implemented feature" is invoked.
-            
+
         Returns:
-            SymbLayerCfg[InputLayer]: The symbolic config for the product of two input layers.
+            SymbLayerCfg[InputLayer]: The symbolic config for the product of the two input layers.
         """
         raise NotImplementedError("The product of DiffEFLayer is not yet implemented.")

--- a/cirkit/new/layers/input/exp_family/exp_family.py
+++ b/cirkit/new/layers/input/exp_family/exp_family.py
@@ -206,25 +206,25 @@ class ExpFamilyLayer(InputLayer):
         self_symb_cfg: SymbLayerCfg[Self],
         other_symb_cfg: SymbLayerCfg[InputLayer],
     ) -> SymbLayerCfg[InputLayer]:
-        """Get the symbolic config to construct the product of this input layer \
-            with the other input layer.
-        
-        Cases:
-            - Product with class in ExpFamilyLayer: f_1*f_2(x) according to the \
-                construction in ProdEFLayer class.
+        """Get the symbolic config to construct the product of this input layer with the other \
+        input layer.
+
+        TODO: Cases:
+            - Product with class in ExpFamilyLayer: f_1*f_2(x) according to the construction in \
+                ProdEFLayer.
             - Product with ConstantLayer: f(x)*c.
-            - Product with DiffEFLayer: f_1(x)*f_2'(x). 
-        
+            - Product with DiffEFLayer: f_1(x)*f_2'(x).
+
         Args:
             self_symb_cfg (SymbLayerCfg[Self]): The symbolic config for this layer.
-            other_symb_cfg (SymbLayerCfg[InputLayer]): The symbolic config for the other layer \
+            other_symb_cfg (SymbLayerCfg[InputLayer]): The symbolic config for the other layer, \
                 must be of InputLayer.
 
         Raises:
             NotImplementedError: When "not-yet-implemented feature" is invoked.
 
         Returns:
-            SymbLayerCfg[InputLayer]: The symbolic config for the product of two input layers.
+            SymbLayerCfg[InputLayer]: The symbolic config for the product of the two input layers.
         """
         # DISABLE: We must import here to avoid cyclic import.
         # pylint: disable-next=import-outside-toplevel,cyclic-import
@@ -239,6 +239,7 @@ class ExpFamilyLayer(InputLayer):
                     "ef2_cfg": other_symb_cfg,
                 },
             )
+
         raise NotImplementedError(
             "Product for EF input layer and other input layers not implemented."
         )

--- a/cirkit/new/layers/input/exp_family/prod_ef.py
+++ b/cirkit/new/layers/input/exp_family/prod_ef.py
@@ -160,14 +160,14 @@ class ProdEFLayer(ExpFamilyLayer):
             SymbLayerCfg[InputLayer]: The symbolic config for the partial differential w.r.t. the \
                 given channel of the given variable.
         """
-        # TODO: support nested ProdEFLayer (3 or more products)
-        # TODO: how to check continuous/discrete distribution
-        # CAST: kwargs.get gives Any.
-        # IGNORE: Unavoidable for kwargs.
         # DISABLE: We must import here to avoid cyclic import.
         # pylint: disable-next=import-outside-toplevel,cyclic-import
         from cirkit.new.layers.input.exp_family.categorical import CategoricalLayer
 
+        # TODO: support nested ProdEFLayer (3 or more products)
+        # TODO: how to check continuous/discrete distribution
+        # CAST: kwargs.get gives Any.
+        # IGNORE: Unavoidable for kwargs.
         if CategoricalLayer in (
             cast(
                 SymbLayerCfg[ExpFamilyLayer],
@@ -181,3 +181,6 @@ class ProdEFLayer(ExpFamilyLayer):
             raise TypeError("Cannot differentiate over discrete variables.")
 
         return super().get_partial(symb_cfg, order=order, var_idx=var_idx, ch_idx=ch_idx)
+
+    # NOTE: get_product is inherited from ExpFamilyLayer. For cascaded product this will lead to a
+    #       binary tree of ProdEFLayer.

--- a/cirkit/new/layers/input/input.py
+++ b/cirkit/new/layers/input/input.py
@@ -81,8 +81,8 @@ class InputLayer(Layer):
         self_symb_cfg: SymbLayerCfg[Self],
         other_symb_cfg: SymbLayerCfg["InputLayer"],
     ) -> SymbLayerCfg["InputLayer"]:
-        """Get the symbolic config to construct the product of this input layer \
-            with the other input layer.
+        """Get the symbolic config to construct the product of this input layer with the other \
+        input layer.
 
         Args:
             self_symb_cfg (SymbLayerCfg[Self]): The symbolic config for this layer.
@@ -90,5 +90,5 @@ class InputLayer(Layer):
                 must be of InputLayer.
 
         Returns:
-            SymbLayerCfg[InputLayer]: The symbolic config for the product of two input layers.
+            SymbLayerCfg[InputLayer]: The symbolic config for the product of the two input layers.
         """

--- a/cirkit/new/symbolic/functional.py
+++ b/cirkit/new/symbolic/functional.py
@@ -6,7 +6,7 @@ import heapq
 import itertools
 from typing import TYPE_CHECKING, Dict, Iterable, List, NamedTuple, Optional, Tuple
 
-from cirkit.new.layers.inner.product.kronecker import KroneckerLayer
+from cirkit.new.layers import KroneckerLayer
 from cirkit.new.symbolic.symbolic_layer import (
     SymbolicInputLayer,
     SymbolicLayer,
@@ -269,7 +269,7 @@ def product(
 
     # ANNOTATE: Specify content for empty container.
     # Map between self circuit to product circuit, other circuit to product circuit.
-    self_to_product: Dict[SymbolicLayer, SymbolicLayer] = {}
+    self_to_product: Dict[SymbolicLayer, SymbolicLayer] = {}  # TODO: leftover of different scope
     other_to_product: Dict[SymbolicLayer, SymbolicLayer] = {}
 
     def _copy_layer(
@@ -298,6 +298,7 @@ def product(
         """Perform product between two layers."""
         new_layer: SymbolicLayer
 
+        # TODO: leftover of different scope prod
         # product layer is already generated
         if self_layer in self_to_product and other_layer in other_to_product:
             assert (
@@ -316,7 +317,9 @@ def product(
                 # Kroneker product configuration to connect two sub-circuits with distinct scope.
                 layer_cfg=SymbLayerCfg(layer_cls=KroneckerLayer),
             )
+        # TODO: leftover of different scope prod
 
+        # TODO: fuse the following cases for get_product?
         elif isinstance(self_layer, SymbolicInputLayer) and isinstance(
             other_layer, SymbolicInputLayer
         ):
@@ -326,7 +329,7 @@ def product(
                 raise ValueError("Both layers must have a reparameterization")
 
             # IGNORE: Unavoidable for kwargs.
-            new_layer = SymbolicInputLayer(
+            new_layer = type(self_layer)(
                 self_layer.scope,
                 (),
                 num_units=self_layer.num_units * other_layer.num_units,
@@ -364,6 +367,7 @@ def product(
                 len(self_layer_inputs) == 2 and len(other_layer_inputs) == 2
             ), "product layers only allow for 2 inputs"
 
+            # TODO: automatically aligned due to scope sorting?
             # align the inputs to have the same or similar scope
             aligned_inputs = [
                 (self_input, other_input)


### PR DESCRIPTION
Added `get_product()` 

currently support same scope product, have un-implemented templates for different scope product, the cases written with `TODO` would need to be discussed (ideally implement them in the actual layers, and keep `reparam=self_symb_cfg.reparam` in `get_product()` 

The cases without `TODO` are not urgent and could be ignored for now

Note that to simplify `get_product()` (avoid too many cases), calling `self_layer.get_product()` and `other_layer.get_product()` is different: e.g. if `self_layer` is input layer and `other_layer` is product layer, should always call `other_layer.get_product()`, `self_layer.get_product()` in this case would raise an error. 

Discuss: 
**Could you check if `id(cls)` and `id(CLASS_NAME)` are different within the class methods? In my case the memory ids are different, so I only used `issubclass(other_symb_cfg.layer_cls, cls)`. Might be a potential bug? **

Discuss how the `TODO` would be implemented, which are the different cases for different-scope-product we discussed earlier

