### PR TITLE
Update dependencies etc.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,20 +14,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out with submodules
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Truncate pyproject for hashing
+        run: |
+          sed -n '1,/#\{80\}/p' pyproject.toml > pyproject-hash.toml
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
           cache: 'pip'
-          cache-dependency-path: pyproject.toml
+          cache-dependency-path: pyproject-hash.toml
       - name: Cache mypy_cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .mypy_cache
-          key: mypy_cache-${{ hashFiles('pyproject.toml') }}
+          key: mypy_cache-${{ hashFiles('pyproject-hash.toml') }}
           restore-keys: mypy_cache-
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - name: Truncate pyproject for hashing
+        run: |
+          sed -n '1,/#\{80\}/p' pyproject.toml > pyproject-hash.toml
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
           cache: 'pip'
-          cache-dependency-path: pyproject.toml
+          cache-dependency-path: pyproject-hash.toml
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -29,7 +32,7 @@ jobs:
         run: |
           ./scripts/coverage.sh --xml
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
-  "torch~=2.1.0",
+  "torch~=2.2.0",
   "numpy>=1.24.0",
 ]
 
@@ -45,11 +45,18 @@ test = [
   "pytest-cov",
 ]
 notebooks = [
-  "torchvision"
+  "notebook",
+  "torchvision",
 ]
 
 [project.urls]
 "Homepage" = "https://github.com/april-tools/cirkit"
+
+################################################################################
+# Anything below this line does count to the "hash of pyproject" in workflows,
+# as they are for development tools but not project release.
+
+# Configs for testing. Rules for coverage may be changed to reflect unreachable-by-design.
 
 # unit test
 [tool.pytest.ini_options]
@@ -60,21 +67,19 @@ testpaths = ["tests"]
 [tool.coverage.run]
 branch = true
 source = ["cirkit"]
-
 [tool.coverage.report]
 show_missing = true
 exclude_also = [  # regex for exclusion
   '@overload',
 ]
 
-# Following are configs for code quality checks. Any change should be put into
-# a separate PR and merge with care. Rules can only be modified after discussion.
+# Configs for linting. Rules may be changed/lifted with a good reason.
 
 # code style
 [tool.black]
 line-length = 100
 target-version = ["py38"]
-required-version = 23
+required-version = "23"
 
 # import style
 [tool.isort]
@@ -158,8 +163,8 @@ default-docstring-type = "google"
 
 # type checking
 [tool.mypy]
-python_version = 3.8
-mypy_path = "3rd-party-stubs"
+python_version = "3.8"
+mypy_path = "3rd-party-stubs"  # TODO: for old version, check deprecation for cirkit.new
 follow_imports = "silent"
 follow_imports_for_stubs = true
 # https://mypy.readthedocs.io/en/stable/config_file.html#miscellaneous


### PR DESCRIPTION
1. Updated `torch` to 2.2;
2. Updated actions in response to https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/;
3. Changed workflow cache key to rely on only the project (dependencies) in pyproject but not tool configs (linting rules).