### PR TITLE
Fix for Documentation Build Error caused by 'HypercubeToScope' and 'Hypercube'

### DIFF
--- a/cirkit/templates/region_graph/algorithms/__init__.py
+++ b/cirkit/templates/region_graph/algorithms/__init__.py
@@ -5,3 +5,5 @@ from .poon_domingos import PoonDomingos as PoonDomingos
 from .quad import QuadGraph as QuadGraph
 from .quad import QuadTree as QuadTree
 from .random import RandomBinaryTree as RandomBinaryTree
+from .utils import HyperCube as HyperCube
+from .utils import HypercubeToScope as HypercubeToScope


### PR DESCRIPTION
Fixes https://github.com/april-tools/cirkit/issues/285.