### PR TITLE
Merged dense and mixing layer into sum layer

### DIFF
--- a/cirkit/backend/torch/compiler.py
+++ b/cirkit/backend/torch/compiler.py
@@ -548,6 +548,7 @@ def _match_layer_pattern(
     outcomings_fn: Callable[[TorchLayer], Sequence[TorchLayer]],
 ) -> LayerOptMatch | None:
     ppatterns = pattern.ppatterns()
+    cpatterns = pattern.cpatterns()
     pattern_entries = pattern.entries()
     num_entries = len(pattern_entries)
     matched_layers = []
@@ -566,7 +567,12 @@ def _match_layer_pattern(
         if len(out_nodes) > 1 and lid != 0:
             return None
 
-        # Second, attempt to match the patterns specified for its parameters
+        # Second, attempt to match the configuration patterns for the layer
+        for cname, cvalue in cpatterns[lid].items():
+            if layer.config[cname] != cvalue:
+                return None
+
+        # Third, attempt to match the patterns specified for its parameters
         lpmatches = {}
         for pname, ppattern in ppatterns[lid].items():
             pgraph = layer.params[pname]

--- a/cirkit/backend/torch/layers/__init__.py
+++ b/cirkit/backend/torch/layers/__init__.py
@@ -1,9 +1,7 @@
 from .base import TorchLayer as TorchLayer
-from .inner import TorchDenseLayer as TorchDenseLayer
 from .inner import TorchHadamardLayer as TorchHadamardLayer
 from .inner import TorchInnerLayer as TorchInnerLayer
 from .inner import TorchKroneckerLayer as TorchKroneckerLayer
-from .inner import TorchMixingLayer as TorchMixingLayer
 from .inner import TorchProductLayer as TorchProductLayer
 from .inner import TorchSumLayer as TorchSumLayer
 from .input import TorchCategoricalLayer as TorchCategoricalLayer

--- a/cirkit/backend/torch/layers/inner.py
+++ b/cirkit/backend/torch/layers/inner.py
@@ -50,10 +50,6 @@ class TorchProductLayer(TorchInnerLayer, ABC):
     ...
 
 
-class TorchSumLayer(TorchInnerLayer, ABC):
-    ...
-
-
 class TorchHadamardLayer(TorchProductLayer):
     """The Hadamard product layer."""
 
@@ -171,13 +167,14 @@ class TorchKroneckerLayer(TorchProductLayer):
         return torch.flatten(x, start_dim=2, end_dim=3), None
 
 
-class TorchDenseLayer(TorchSumLayer):
-    """The sum layer for dense sum within a layer."""
+class TorchSumLayer(TorchInnerLayer):
+    """The sum layer."""
 
     def __init__(
         self,
         num_input_units: int,
         num_output_units: int,
+        arity: int = 1,
         *,
         weight: TorchParameter,
         semiring: Semiring | None = None,
@@ -192,91 +189,7 @@ class TorchDenseLayer(TorchSumLayer):
             num_folds (int): The number of channels. Defaults to 1.
         """
         assert weight.num_folds == num_folds
-        assert weight.shape == (num_output_units, num_input_units)
-        super().__init__(
-            num_input_units, num_output_units, arity=1, semiring=semiring, num_folds=num_folds
-        )
-        self.weight = weight
-
-    @property
-    def config(self) -> Mapping[str, Any]:
-        return {"num_input_units": self.num_input_units, "num_output_units": self.num_output_units}
-
-    @property
-    def params(self) -> Mapping[str, TorchParameter]:
-        return {"weight": self.weight}
-
-    def forward(self, x: Tensor) -> Tensor:
-        """Run forward pass.
-
-        Args:
-            x (Tensor): The input to this layer, shape (F, H, B, Ki).
-
-        Returns:
-            Tensor: The output of this layer, shape (F, B, Ko).
-        """
-        x = x.squeeze(dim=1)  # shape (F, H=1, B, Ki) -> (F, B, Ki).
-        weight = self.weight()
-        return self.semiring.einsum(
-            "fbi,foi->fbo", inputs=(x,), operands=(weight,), dim=-1, keepdim=True
-        )  # shape (F, B, Ko).
-
-    def sample(self, x: Tensor) -> tuple[Tensor, Tensor]:
-        weight = self.weight()
-        negative = torch.any(weight < 0.0)
-        if negative:
-            raise ValueError("Sampling only works with positive weights")
-        normalized = torch.allclose(torch.sum(weight, dim=-1), torch.ones(1, device=weight.device))
-        if not normalized:
-            raise ValueError("Sampling only works with a normalized parametrization")
-
-        # x: (F, H, C, K, num_samples, D)
-        c = x.shape[2]
-        d = x.shape[-1]
-        num_samples = x.shape[-2]
-
-        # mixing_distribution: (F, O, K)
-        mixing_distribution = torch.distributions.Categorical(probs=weight)
-
-        mixing_samples = mixing_distribution.sample((num_samples,))
-        mixing_samples = E.rearrange(mixing_samples, "n f o -> f o n")
-        mixing_indices = E.repeat(mixing_samples, "f o n -> f a c o n d", a=self.arity, c=c, d=d)
-
-        x = torch.gather(x, dim=-3, index=mixing_indices)
-        x = x[:, 0]
-        return x, mixing_samples
-
-
-class TorchMixingLayer(TorchSumLayer):
-    """The sum layer for mixture among layers.
-
-    It can also be used as a sparse sum within a layer when arity=1.
-    """
-
-    def __init__(
-        self,
-        num_input_units: int,
-        num_output_units: int,
-        arity: int = 2,
-        *,
-        weight: TorchParameter,
-        semiring: Semiring | None = None,
-        num_folds: int = 1,
-    ) -> None:
-        """Init class.
-
-        Args:
-            num_input_units (int): The number of input units.
-            num_output_units (int): The number of output units, must be the same as input.
-            arity (int, optional): The arity of the layer. Defaults to 2.
-            weight (TorchParameter): The reparameterization for layer parameters.
-            num_folds (int): The number of channels. Defaults to 1.
-        """
-        assert (
-            num_output_units == num_input_units
-        ), "The number of input and output units must be the same for MixingLayer."
-        assert weight.num_folds == num_folds
-        assert weight.shape == (num_output_units, arity)
+        assert weight.shape == (num_output_units, arity * num_input_units)
         super().__init__(
             num_input_units, num_output_units, arity=arity, semiring=semiring, num_folds=num_folds
         )
@@ -303,11 +216,13 @@ class TorchMixingLayer(TorchSumLayer):
         Returns:
             Tensor: The output of this layer, shape (F, B, Ko).
         """
-        # shape (F, H, B, K) -> (F, B, K).
+        # x: (F, H, B, Ki) -> (F, B, H * Ki)
+        # weight: (F, Ko, H * Ki)
+        x = x.permute(0, 2, 1, 3).flatten(start_dim=2)
         weight = self.weight()
         return self.semiring.einsum(
-            "fhbk,fkh->fbk", inputs=(x,), operands=(weight,), dim=1, keepdim=False
-        )
+            "fbi,foi->fbo", inputs=(x,), operands=(weight,), dim=-1, keepdim=True
+        )  # shape (F, B, Ko).
 
     def sample(self, x: Tensor) -> tuple[Tensor, Tensor]:
         weight = self.weight()
@@ -318,18 +233,22 @@ class TorchMixingLayer(TorchSumLayer):
         if not normalized:
             raise ValueError("Sampling only works with a normalized parametrization")
 
-        # x: (F, H, C, K, num_samples, D)
-        c = x.shape[2]
-        k = x.shape[-3]
-        d = x.shape[-1]
-        num_samples = x.shape[-2]
+        # x: (F, H, C, Ki, num_samples, D) -> (F, C, H * Ki, num_samples, D)
+        x = x.permute(0, 2, 1, 3, 4, 5).flatten(2, 3)
+        c = x.shape[1]
+        num_samples = x.shape[3]
+        d = x.shape[4]
 
-        # mixing_distribution: (F, O, K)
+        # mixing_distribution: (F, Ko, H * Ki)
         mixing_distribution = torch.distributions.Categorical(probs=weight)
 
+        # mixing_samples: (num_samples, F, Ko) -> (F, Ko, num_samples)
         mixing_samples = mixing_distribution.sample((num_samples,))
         mixing_samples = E.rearrange(mixing_samples, "n f k -> f k n")
-        mixing_indices = E.repeat(mixing_samples, "f k n -> f 1 c k n d", c=c, k=k, d=d)
 
-        x = torch.gather(x, 1, mixing_indices)[:, 0]
+        # mixing_indices: (F, C, Ko, num_samples, D)
+        mixing_indices = E.repeat(mixing_samples, "f k n -> f c k n d", c=c, d=d)
+
+        # x: (F, C, Ko, num_samples, D)
+        x = torch.gather(x, dim=2, index=mixing_indices)
         return x, mixing_samples

--- a/cirkit/backend/torch/layers/input.py
+++ b/cirkit/backend/torch/layers/input.py
@@ -296,9 +296,7 @@ class TorchCategoricalLayer(TorchExpFamilyLayer):
                 raise ValueError(f"The number of folds and shape of 'probs' must match the layer's")
         self.probs = probs
         self.logits = logits
-        self.idx_mode = (
-            len(torch.unique(self.scope_idx)) > 4096 or self.num_categories > 256
-        )
+        self.idx_mode = len(torch.unique(self.scope_idx)) > 4096 or self.num_categories > 256
 
     def _valid_parameter_shape(self, p: TorchParameter) -> bool:
         if p.num_folds != self.num_folds:

--- a/cirkit/backend/torch/layers/optimized.py
+++ b/cirkit/backend/torch/layers/optimized.py
@@ -1,4 +1,3 @@
-from abc import ABC
 from collections.abc import Mapping
 from typing import Any
 
@@ -6,16 +5,12 @@ import einops as E
 import torch
 from torch import Tensor
 
-from cirkit.backend.torch.layers import TorchInnerLayer, TorchSumLayer
+from cirkit.backend.torch.layers import TorchInnerLayer
 from cirkit.backend.torch.parameters.parameter import TorchParameter
 from cirkit.backend.torch.semiring import Semiring
 
 
-class TorchSumProductLayer(TorchInnerLayer, ABC):
-    ...
-
-
-class TorchTuckerLayer(TorchSumProductLayer):
+class TorchTuckerLayer(TorchInnerLayer):
     """The Tucker (2) layer, which is a fused dense-kronecker.
 
     A ternary einsum is used to fuse the sum and product.
@@ -81,7 +76,7 @@ class TorchTuckerLayer(TorchSumProductLayer):
         )
 
 
-class TorchCPTLayer(TorchSumProductLayer):
+class TorchCPTLayer(TorchInnerLayer):
     """The Candecomp Parafac (collapsed) layer, which is a fused dense-hadamard.
 
     The fusion actually does not gain anything, and is just a plain connection. We don't because \
@@ -173,7 +168,7 @@ class TorchCPTLayer(TorchSumProductLayer):
         return x, mixing_samples
 
 
-class TorchTensorDotLayer(TorchSumLayer):
+class TorchTensorDotLayer(TorchInnerLayer):
     """The sum layer for dense sum within a layer."""
 
     def __init__(

--- a/cirkit/backend/torch/optimization/registry.py
+++ b/cirkit/backend/torch/optimization/registry.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from cirkit.backend.registry import CompilerRegistry
 from cirkit.backend.torch.graph.optimize import GraphOptMatch, GraphOptPatternDefn
@@ -29,7 +29,11 @@ class LayerOptPatternDefn(GraphOptPatternDefn[TorchLayer]):
 
     @classmethod
     def ppatterns(cls) -> list[dict[str, ParameterOptPattern]]:
-        return [{} for _ in cls.entries()]
+        ...
+
+    @classmethod
+    def cpatterns(cls) -> list[dict[str, Any]]:
+        ...
 
 
 LayerOptPattern = type[LayerOptPatternDefn]

--- a/cirkit/backend/torch/rules/layers.py
+++ b/cirkit/backend/torch/rules/layers.py
@@ -3,12 +3,7 @@ from typing import TYPE_CHECKING, cast
 import torch
 
 from cirkit.backend.compiler import LayerCompilationFunc, LayerCompilationSign
-from cirkit.backend.torch.layers.inner import (
-    TorchDenseLayer,
-    TorchHadamardLayer,
-    TorchKroneckerLayer,
-    TorchMixingLayer,
-)
+from cirkit.backend.torch.layers.inner import TorchHadamardLayer, TorchKroneckerLayer, TorchSumLayer
 from cirkit.backend.torch.layers.input import (
     TorchBinomialLayer,
     TorchCategoricalLayer,
@@ -23,14 +18,13 @@ from cirkit.symbolic.layers import (
     BinomialLayer,
     CategoricalLayer,
     ConstantValueLayer,
-    DenseLayer,
     EmbeddingLayer,
     EvidenceLayer,
     GaussianLayer,
     HadamardLayer,
     KroneckerLayer,
-    MixingLayer,
     PolynomialLayer,
+    SumLayer,
 )
 
 if TYPE_CHECKING:
@@ -131,16 +125,9 @@ def compile_kronecker_layer(compiler: "TorchCompiler", sl: KroneckerLayer) -> To
     )
 
 
-def compile_dense_layer(compiler: "TorchCompiler", sl: DenseLayer) -> TorchDenseLayer:
+def compile_sum_layer(compiler: "TorchCompiler", sl: SumLayer) -> TorchSumLayer:
     weight = compiler.compile_parameter(sl.weight)
-    return TorchDenseLayer(
-        sl.num_input_units, sl.num_output_units, weight=weight, semiring=compiler.semiring
-    )
-
-
-def compile_mixing_layer(compiler: "TorchCompiler", sl: MixingLayer) -> TorchMixingLayer:
-    weight = compiler.compile_parameter(sl.weight)
-    return TorchMixingLayer(
+    return TorchSumLayer(
         sl.num_input_units,
         sl.num_output_units,
         arity=sl.arity,
@@ -177,8 +164,7 @@ DEFAULT_LAYER_COMPILATION_RULES: dict[LayerCompilationSign, LayerCompilationFunc
     PolynomialLayer: compile_polynomial_layer,
     HadamardLayer: compile_hadamard_layer,
     KroneckerLayer: compile_kronecker_layer,
-    DenseLayer: compile_dense_layer,
-    MixingLayer: compile_mixing_layer,
+    SumLayer: compile_sum_layer,
     ConstantValueLayer: compile_constant_value_layer,
     EvidenceLayer: compile_evidence_layer,
 }

--- a/tests/symbolic/test_from_region_graph.py
+++ b/tests/symbolic/test_from_region_graph.py
@@ -1,6 +1,6 @@
 from cirkit.symbolic.circuit import Circuit
 from cirkit.symbolic.initializers import DirichletInitializer
-from cirkit.symbolic.layers import CategoricalLayer, DenseLayer, MixingLayer
+from cirkit.symbolic.layers import CategoricalLayer, SumLayer
 from cirkit.symbolic.parameters import Parameter, TensorParameter
 from cirkit.templates.region_graph import QuadGraph, QuadTree
 from cirkit.utils.scope import Scope
@@ -40,14 +40,14 @@ def test_build_circuit_qg_3x3_cp():
         isinstance(sl, CategoricalLayer) and len(sc.layer_scope(sl)) == 1 for sl in sc.inputs
     )
     assert len(list(sc.product_layers)) == 14
-    assert len(list(sl for sl in sc.sum_layers if isinstance(sl, DenseLayer))) == 30
-    assert len(list(sl for sl in sc.sum_layers if isinstance(sl, MixingLayer))) == 2
+    assert len(list(sl for sl in sc.sum_layers if isinstance(sl, SumLayer) and sl.arity == 1)) == 30
+    assert len(list(sl for sl in sc.sum_layers if isinstance(sl, SumLayer) and sl.arity > 1)) == 2
     assert (
         len(list(sl for sl in sc.product_layers if sc.layer_scope(sl) == Scope([0, 1, 3, 4]))) == 2
     )
     assert len(list(sl for sl in sc.product_layers if sc.layer_scope(sl) == Scope(range(9)))) == 2
     (out_sl,) = sc.outputs
-    assert isinstance(out_sl, MixingLayer)
+    assert isinstance(out_sl, SumLayer) and out_sl.arity > 1
 
 
 def test_build_circuit_qt4_3x3_cp():
@@ -67,8 +67,8 @@ def test_build_circuit_qt4_3x3_cp():
         isinstance(sl, CategoricalLayer) and len(sc.layer_scope(sl)) == 1 for sl in sc.inputs
     )
     assert len(list(sc.product_layers)) == 4
-    assert len(list(sl for sl in sc.sum_layers if isinstance(sl, DenseLayer))) == 13
-    assert len(list(sl for sl in sc.sum_layers if isinstance(sl, MixingLayer))) == 0
+    assert len(list(sl for sl in sc.sum_layers if isinstance(sl, SumLayer) and sl.arity == 1)) == 13
+    assert len(list(sl for sl in sc.sum_layers if isinstance(sl, SumLayer) and sl.arity > 1)) == 0
     assert all(
         len(sc.layer_inputs(sl)) == 2 for sl in sc.product_layers if len(sc.layer_scope(sl)) == 2
     )
@@ -76,4 +76,4 @@ def test_build_circuit_qt4_3x3_cp():
         len(sc.layer_inputs(sl)) == 4 for sl in sc.product_layers if len(sc.layer_scope(sl)) > 2
     )
     (out_sl,) = sc.outputs
-    assert isinstance(out_sl, DenseLayer)
+    assert isinstance(out_sl, SumLayer) and out_sl.arity == 1

--- a/tests/symbolic/test_utils.py
+++ b/tests/symbolic/test_utils.py
@@ -11,11 +11,11 @@ from cirkit.symbolic.initializers import (
 )
 from cirkit.symbolic.layers import (
     CategoricalLayer,
-    DenseLayer,
     GaussianLayer,
     HadamardLayer,
     Layer,
     PolynomialLayer,
+    SumLayer,
 )
 from cirkit.symbolic.parameters import (
     ExpParameter,
@@ -99,7 +99,7 @@ def build_bivariate_monotonic_structured_cpt_pc(
             TensorParameter(*shape, initializer=DirichletInitializer())
         )
     dense_layers = {
-        scope: DenseLayer(
+        scope: SumLayer(
             num_input_units=num_units,
             num_output_units=1 if len(scope) == 2 else num_units,
             weight_factory=dense_weight_factory,
@@ -222,7 +222,7 @@ def build_multivariate_monotonic_structured_cpt_pc(
             TensorParameter(*shape, initializer=DirichletInitializer())
         )
     dense_layers = {
-        scope: DenseLayer(
+        scope: SumLayer(
             num_input_units=num_units,
             num_output_units=1 if len(scope) == 5 else num_units,
             weight_factory=dense_weight_factory,
@@ -296,7 +296,7 @@ def build_monotonic_structured_categorical_cpt_pc(
             bernoulli_probs[tuple(sl.scope)]
         )
     for sl in circuit.sum_layers:
-        assert isinstance(sl, DenseLayer)
+        assert isinstance(sl, SumLayer)
         next(sl.weight.inputs).initializer = ConstantTensorInitializer(
             dense_weights[tuple(circuit.layer_scope(sl))]
         )
@@ -419,7 +419,7 @@ def build_monotonic_bivariate_gaussian_hadamard_dense_pc(
             gaussian_mean_stddev[tuple(sl.scope)][1]
         )
     for sl in circuit.sum_layers:
-        assert isinstance(sl, DenseLayer)
+        assert isinstance(sl, SumLayer)
         next(sl.weight.inputs).initializer = ConstantTensorInitializer(
             dense_weights[tuple(circuit.layer_scope(sl))]
         )


### PR DESCRIPTION
As we discussed and to avoid any confusion, this merges dense and mixing layers into a more general sum layer.

Detailed changes:
- Replaced symbolic mixing and dense layers with a symbolic sum layer.
- Add ```SumLayer.from_mixing_weights``` method that returns a sum layer whose weights are constant (i.e., non-learnable) and encoding an average of the input vectors. This is used by default in the ```Circuit.from_region_graph``` method where no mixing layer factory is proved.
- Fused torch dense and mixing layer implementations into a single one. When compared to cirkit==0.1.0 you might notice an increase in the total number of parameters. This is normal as the sparse weights in mixing layers are now stored in dense weights of sum layers.
- Updated torch layer optimization rules as to apply known optimizations only for sum layers having arity=1 (i.e., the previously known dense layers)
- Re-run affected notebooks