### PR TITLE
Correct links to github in the documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: cirkit
 site_url: https://cirkit-docs.readthedocs.io
 repo_url: https://github.com/april-tools/cirkit
+edit_uri: blob/main
 nav:
   - Getting Started: 'index.md'
   - Notebooks:


### PR DESCRIPTION
Trying to understand the API I realized that links pointing to source code do not work in the documentation.

![image](https://github.com/user-attachments/assets/7a2bea75-f94a-4bdd-acd2-d383510287c8)

For example, the buttons in https://cirkit-docs.readthedocs.io/en/stable/api/cirkit/pipeline/ point to 
- View: https://github.com/april-tools/cirkit/raw/master/docs/cirkit/pipeline.py
- Edit: https://github.com/april-tools/cirkit/edit/master/docs/cirkit/pipeline.py

Instead, it should point to:
- View: https://github.com/april-tools/cirkit/raw/main/cirkit/pipeline.py
- Edit: https://github.com/april-tools/cirkit/blob/main/cirkit/pipeline.py

Luckily, the fix is as simple as adding one extra line to the mkdocs configuration.

I've tested it with `mkdocs serve` in local and it works now.