### PR TITLE
ordered scope when iterating

### DIFF
--- a/cirkit/utils/scope.py
+++ b/cirkit/utils/scope.py
@@ -4,6 +4,10 @@ class Scope(frozenset[int]):
     but for efficiency this is not checked.
     """
 
+    def __iter__(self):
+        """Ensure iteration happens in sorted order."""
+        return iter(sorted(super().__iter__()))
+
     def __repr__(self) -> str:
         """Generate the repr string of the scope, for repr().
 


### PR DESCRIPTION
I found out that iterating on ordered scopes could be "beneficial" when creating circuits for RGB images, as it ensures a consistent pattern in the indices required for folding.
