### PR TITLE
Add Chow-Liu and HMM image region graphs

### DIFF
--- a/cirkit/backend/torch/rules/layers.py
+++ b/cirkit/backend/torch/rules/layers.py
@@ -37,9 +37,7 @@ if TYPE_CHECKING:
     from cirkit.backend.torch.compiler import TorchCompiler
 
 
-def compile_embedding_layer(
-    compiler: "TorchCompiler", sl: EmbeddingLayer
-) -> TorchEmbeddingLayer:
+def compile_embedding_layer(compiler: "TorchCompiler", sl: EmbeddingLayer) -> TorchEmbeddingLayer:
     weight = compiler.compile_parameter(sl.weight)
     return TorchEmbeddingLayer(
         torch.tensor(tuple(sl.scope)),
@@ -71,9 +69,7 @@ def compile_categorical_layer(
     )
 
 
-def compile_binomial_layer(
-    compiler: "TorchCompiler", sl: BinomialLayer
-) -> TorchBinomialLayer:
+def compile_binomial_layer(compiler: "TorchCompiler", sl: BinomialLayer) -> TorchBinomialLayer:
     if sl.logits is None:
         assert sl.probs is not None
         probs = compiler.compile_parameter(sl.probs)
@@ -92,9 +88,7 @@ def compile_binomial_layer(
     )
 
 
-def compile_gaussian_layer(
-    compiler: "TorchCompiler", sl: GaussianLayer
-) -> TorchGaussianLayer:
+def compile_gaussian_layer(compiler: "TorchCompiler", sl: GaussianLayer) -> TorchGaussianLayer:
     mean = compiler.compile_parameter(sl.mean)
     stddev = compiler.compile_parameter(sl.stddev)
     if sl.log_partition is not None:
@@ -124,20 +118,12 @@ def compile_polynomial_layer(
     )
 
 
-def compile_hadamard_layer(
-    compiler: "TorchCompiler", sl: HadamardLayer
-) -> TorchHadamardLayer:
-    return TorchHadamardLayer(
-        sl.num_input_units, arity=sl.arity, semiring=compiler.semiring
-    )
+def compile_hadamard_layer(compiler: "TorchCompiler", sl: HadamardLayer) -> TorchHadamardLayer:
+    return TorchHadamardLayer(sl.num_input_units, arity=sl.arity, semiring=compiler.semiring)
 
 
-def compile_kronecker_layer(
-    compiler: "TorchCompiler", sl: KroneckerLayer
-) -> TorchKroneckerLayer:
-    return TorchKroneckerLayer(
-        sl.num_input_units, arity=sl.arity, semiring=compiler.semiring
-    )
+def compile_kronecker_layer(compiler: "TorchCompiler", sl: KroneckerLayer) -> TorchKroneckerLayer:
+    return TorchKroneckerLayer(sl.num_input_units, arity=sl.arity, semiring=compiler.semiring)
 
 
 def compile_sum_layer(compiler: "TorchCompiler", sl: SumLayer) -> TorchSumLayer:
@@ -163,9 +149,7 @@ def compile_constant_value_layer(
     )
 
 
-def compile_evidence_layer(
-    compiler: "TorchCompiler", sl: EvidenceLayer
-) -> TorchEvidenceLayer:
+def compile_evidence_layer(compiler: "TorchCompiler", sl: EvidenceLayer) -> TorchEvidenceLayer:
     layer = compiler.compile_layer(sl.layer)
     observation = compiler.compile_parameter(sl.observation)
     return TorchEvidenceLayer(
@@ -175,9 +159,7 @@ def compile_evidence_layer(
     )
 
 
-DEFAULT_LAYER_COMPILATION_RULES: dict[
-    LayerCompilationSign, Callable[..., TorchLayer]
-] = {
+DEFAULT_LAYER_COMPILATION_RULES: dict[LayerCompilationSign, Callable[..., TorchLayer]] = {
     EmbeddingLayer: compile_embedding_layer,
     CategoricalLayer: compile_categorical_layer,
     BinomialLayer: compile_binomial_layer,

--- a/cirkit/templates/data_modalities.py
+++ b/cirkit/templates/data_modalities.py
@@ -8,6 +8,7 @@ from cirkit.symbolic.circuit import Circuit
 from cirkit.symbolic.parameters import ParameterFactory, mixing_weight_factory
 from cirkit.templates.region_graph import (
     ChowLiuTree,
+    LinearTree,
     PoonDomingos,
     QuadGraph,
     QuadTree,
@@ -23,7 +24,39 @@ from cirkit.templates.utils import (
 from cirkit.utils.scope import Scope
 
 
-def image_data(
+def _flatten_image_data(data: Tensor, image_shape: tuple[int, int, int]) -> Tensor:
+    """Flattens image samples into the tabular form required for region-graph learning.
+
+    Accepts data already in tabular form (num_samples, C * H * W), as a full image tensor
+    (num_samples, C, H, W) matching image_shape, or as a single-channel image without the
+    channel axis (num_samples, H, W) when C == 1.
+
+    Args:
+        data (Tensor): The image data to flatten, whose leading axis indexes the samples.
+            Excluding that axis, its shape must be one of (C * H * W,), (C, H, W) matching
+            image_shape, or (H, W) for single-channel images (i.e. when C == 1).
+        image_shape (tuple[int, int, int]): The image shape, given as (C, H, W).
+
+    Returns:
+        The data reshaped into tabular form, i.e. a matrix of shape (num_samples, C * H * W).
+
+    Raises:
+        ValueError: If the shape of data is not compatible with image_shape.
+    """
+    num_variables = image_shape[0] * image_shape[1] * image_shape[2]
+    valid_feature_shapes = [(num_variables,), tuple(image_shape)]
+    if image_shape[0] == 1:
+        valid_feature_shapes.append(tuple(image_shape[1:]))
+    if tuple(data.shape[1:]) not in valid_feature_shapes:
+        raise ValueError(
+            f"Expected image data of shape (num_samples, {image_shape[0]}, {image_shape[1]},"
+            f" {image_shape[2]}) or (num_samples, {num_variables}),"
+            f" but found a tensor of shape {tuple(data.shape)}"
+        )
+    return data.reshape(data.shape[0], num_variables)
+
+
+def image_data(  # pylint: disable=too-many-arguments
     image_shape: tuple[int, int, int],
     region_graph: str = "quad-graph",
     *,
@@ -35,6 +68,9 @@ def image_data(
     input_params: dict[str, Parameterization] | None = None,
     sum_weight_param: Parameterization | None = None,
     use_mixing_weights: bool = True,
+    data: Tensor | None = None,
+    num_bins: int | None = None,
+    mi_chunk_size: int | None = None,
 ) -> Circuit:
     """Constructs a symbolic circuit whose structure is tailored for image data sets.
 
@@ -46,7 +82,11 @@ def image_data(
             'quad-tree-4' (the Quad-Tree with four splits per region node),
             'quad-graph'  (the Quad-Graph region graph),
             'random-binary-tree' (the random binary tree on flattened image pixels),
-            'poon-domingos' (the Poon-Domingos architecture).
+            'poon-domingos' (the Poon-Domingos architecture),
+            'chow-liu-tree' (the Chow-Liu tree / HCLT, learned from data; requires the 'data'
+            argument),
+            'linear-tree' (the linear chain over the flattened image
+            pixels, i.e. the HMM region graph).
         input_layer: The name of the input layer. It can be one of the following:
             'categorical' (encoding a Categorical distribution over pixel channel values),
             'binomial' (encoding a Binomial distribution over pixel channel values),
@@ -55,10 +95,10 @@ def image_data(
         num_input_units: The number of input units per input layer.
         sum_product_layer: The name of the sum-product inner layer. It can be one of the following:
             'cp' (the canonical decomposition layer, consisting of dense layers followed by a
-            hadamard product layer), 'cp-t' (the transposed canonical decomposition layer, consisting
-            of a hadamard product layer followed by a single dense layer), 'tucker' (the Tucker
-            decomposition layer, consisting of a kronecker product layer followed by a single dense
-            layer).
+            hadamard product layer), 'cp-t' (the transposed canonical decomposition layer,
+            consisting of a hadamard product layer followed by a single dense layer), 'tucker'
+            (the Tucker decomposition layer, consisting of a kronecker product layer followed by
+            a single dense layer).
         num_classes: The number of output classes (default=1).
         num_sum_units: The number of sum units in each sum layer, i.e., either dense or mixing
             layer.
@@ -72,12 +112,27 @@ def image_data(
             a matrix-vector product where the vector is the concatenation of input vectors.
             Sum layers having this semantics are also sometimes referred to as "mixing" layers.
             Defaults to True.
+        data: The data tensor from which the 'chow-liu-tree' region graph is learned. It is
+            required when region_graph is 'chow-liu-tree' and ignored otherwise. It can be of shape
+            (num_samples, C, H, W) matching image_shape, flattened (num_samples, C * H * W),
+            or (num_samples, H, W) for single-channel images (C == 1). When input_layer is
+            'gaussian' it must be floating-point; otherwise it is treated as discrete
+            pixel values.
+        num_bins: Used by the categorical, binomial, and embedding 'chow-liu-tree' region graph.
+            If given, the 256 pixel levels are binned into num_bins bins before learning the tree.
+            Must be in [1, 256]. If None, the raw pixel values are used.
+        mi_chunk_size: Only used by the 'chow-liu-tree' region graph. The number of samples
+            per chunk passed to the chunked mutual-information estimators. If None, all samples
+            are processed at once.
 
     Returns:
         Circuit: A symbolic circuit.
 
     Raises:
-        ValueError: If one of the arguments is not one of the specified allowed ones.
+        ValueError:
+            - If one of the arguments is not one of the specified allowed ones.
+            - If region_graph is 'chow-liu-tree' but data is None, num_bins is outside [1, 256], or
+                input_layer is 'gaussian' with non-floating-point data.
     """
     if (
         not isinstance(image_shape, tuple)
@@ -94,6 +149,8 @@ def image_data(
         "quad-graph",
         "random-binary-tree",
         "poon-domingos",
+        "chow-liu-tree",
+        "linear-tree",
     ]:
         raise ValueError(f"Unknown region graph called {region_graph}")
     if input_layer not in ["categorical", "binomial", "embedding", "gaussian"]:
@@ -112,6 +169,59 @@ def image_data(
         case "poon-domingos":
             delta = int(max(np.ceil(image_shape[1] / 8), np.ceil(image_shape[2] / 8)))
             rg = PoonDomingos(image_shape, delta=delta)
+        case "chow-liu-tree":
+            if data is None:
+                raise ValueError("A data tensor is required when region_graph is 'chow-liu-tree'")
+            flattened_data = _flatten_image_data(data, image_shape)
+            match input_layer:
+                case "gaussian":
+                    if not flattened_data.is_floating_point():
+                        raise ValueError(
+                            "A floating-point data tensor is required when input_layer is "
+                            f"'gaussian', but found a tensor of dtype {flattened_data.dtype}"
+                        )
+                    rg_result = ChowLiuTree(
+                        data=flattened_data,
+                        input_type="gaussian",
+                        chunk_size=mi_chunk_size,
+                        as_region_graph=True,
+                    )
+
+                case "categorical" | "binomial" | "embedding":
+                    clt_data = flattened_data.long()
+                    num_categories = 256
+
+                    if num_bins is not None:
+                        if not 1 <= num_bins <= 256:
+                            raise ValueError(
+                                f"Expected num_bins to be in [1, 256], but found {num_bins}"
+                            )
+
+                        # Maps values in {0, ..., 255} to {0, ..., num_bins - 1}
+                        clt_data = (clt_data * num_bins).div(256, rounding_mode="floor")
+                        clt_data = clt_data.clamp_max(num_bins - 1)
+                        num_categories = num_bins
+                    # Categorical, binomial, and embedding image inputs are discrete variables.
+                    # Their Chow-Liu edge weights are computed with the categorical mutual
+                    # information estimator.
+                    rg_result = ChowLiuTree(
+                        data=clt_data,
+                        input_type="categorical",
+                        num_categories=num_categories,
+                        chunk_size=mi_chunk_size,
+                        as_region_graph=True,
+                    )
+
+                case _:
+                    raise ValueError(f"Unsupported input layer called {input_layer}")
+
+            if not isinstance(rg_result, RegionGraph):
+                raise ValueError(f"Expected a RegionGraph, but got {type(rg_result).__name__}")
+            rg = rg_result
+        case "linear-tree":
+            # The linear chain (HMM region graph) over the flattened image pixels,
+            # in their natural row-major order.
+            rg = LinearTree(image_shape[0] * image_shape[1] * image_shape[2])
         case _:
             raise ValueError(f"Unknown region graph called {region_graph}")
 
@@ -229,7 +339,8 @@ def tabular_data(
             - If one of the names of the input layers is not known, or the related arguments.
             - If the number of input layers (the length of the list) does not match the number
                 of features (`num_features` or inferred from `data`).
-            - If `region_graph="random-binary-tree"` but `num_features` is `None` and `data` is None.
+            - If `region_graph="random-binary-tree"` but `num_features` is `None` and `data`
+                is None.
             - If `region_graph="chow-liu-tree"` but `data` is `None`.
             - If `region_graph` is not one of the supported strings.
     """
@@ -246,7 +357,7 @@ def tabular_data(
             rg = RandomBinaryTree(num_features)
         case "chow-liu-tree":
             if data is None:
-                raise ValueError(f"You must pass `data=` if you ask for `chow-liu-tree`.")
+                raise ValueError("You must pass `data=` if you ask for `chow-liu-tree`.")
             rg_result = ChowLiuTree(
                 data=data,
                 input_type=(

--- a/cirkit/templates/region_graph/algorithms/chow_liu.py
+++ b/cirkit/templates/region_graph/algorithms/chow_liu.py
@@ -14,9 +14,9 @@ def ChowLiuTree(
     root: int | None = None,
     chunk_size: int | None = None,
     num_categories: int | None = None,
-    num_bins: int | None = None,
+    cat_bins: int | None = None,
     as_region_graph: bool = True,
-    bin_for_mi: int | None = None,
+    heter_cont_bins: int | None = None,
 ) -> np.ndarray | RegionGraph:
     """Learns a Chow-Liu Tree and returns it either as a
     list of predecessors (Bayesian net) or as region graph (HCLT).
@@ -42,12 +42,12 @@ def ChowLiuTree(
         chunk_size (int | None): Chunked computation, useful in case of large input data.
         num_categories (int | None): Specifies the number of categories in case of
             categorical data.
-        num_bins (int | None): In case of categorical input, it is used to rescale
+        cat_bins (int | None): In case of categorical input, it is used to rescale
             categories in bins for ordinal features, e.g. [0, 255] -> [0, 7],
             which is useful for images.
         as_region_graph (Optional[bool]): True to returns a region graph,
             False to return a list of predecessors. Defaults to True.
-        bin_for_mi (int | None): For heterogeneous (list) input, the number of bins used to
+        heter_cont_bins (int | None): For heterogeneous (list) input, the number of bins used to
             discretize the continuous features so the whole MI matrix is estimated with the
             categorical estimator; if None, the mixed Gaussian/categorical estimator is used.
 
@@ -64,16 +64,16 @@ def ChowLiuTree(
         is_categorical_mask = [name == "categorical" for name in input_type]
         mutual_info = (
             _heterogeneous_mutual_info(data, is_categorical_mask=is_categorical_mask)
-            if bin_for_mi is None
+            if heter_cont_bins is None
             else _heterogeneous_mutual_info_bin(
-                data, is_categorical_mask=is_categorical_mask, bins=bin_for_mi
+                data, is_categorical_mask=is_categorical_mask, bins=heter_cont_bins
             )
         )
     elif input_type == "categorical":
-        if num_bins is not None:
+        if cat_bins is not None:
             if num_categories is None:
                 raise ValueError("Number of categories must be known if rescaling in bins")
-            data = torch.div(data, num_categories // num_bins, rounding_mode="floor")
+            data = torch.div(data, num_categories // cat_bins, rounding_mode="floor")
         mutual_info = _categorical_mutual_info(
             data.long(), num_categories=num_categories, chunk_size=chunk_size
         )

--- a/cirkit/templates/region_graph/algorithms/chow_liu.py
+++ b/cirkit/templates/region_graph/algorithms/chow_liu.py
@@ -222,23 +222,6 @@ def _gaussian_mutual_info(
     return mutual_info.fill_diagonal_(0)
 
 
-def _heterogeneous_mutual_info_bin(
-    data: Tensor, is_categorical_mask: list[bool], bins: int = 10
-) -> Tensor:
-
-    is_categorical = torch.tensor(is_categorical_mask, dtype=torch.bool, device=data.device)
-    continuous_subset = torch.where(~is_categorical)[0]
-
-    x = data[:, continuous_subset].clone()
-    x = (x - x.min(dim=0, keepdim=True).values) * bins / x.max(dim=0, keepdim=True).values
-    x = x.round()
-
-    discretized_data = data.clone()
-    discretized_data[:, continuous_subset] = x
-
-    return _categorical_mutual_info(discretized_data.long()).float()
-
-
 def _heterogeneous_mutual_info(
     data: Tensor, is_categorical_mask: list[bool], normalize: bool = True
 ) -> Tensor:
@@ -338,3 +321,39 @@ def _heterogeneous_mutual_info(
         mi_matrix = 2 * mi_matrix / (entropy.unsqueeze(0) + entropy.unsqueeze(1))
 
     return mi_matrix.fill_diagonal_(0)
+
+
+def _heterogeneous_mutual_info_bin(
+    data: Tensor, is_categorical_mask: list[bool], bins: int = 10
+) -> Tensor:
+    """Computes the mutual information (MI) matrix for heterogeneous data by binning.
+
+    Differently from `_heterogeneous_mutual_info`, which treats the continuous variables as a
+    Multivariate Gaussian, this estimator discretizes each continuous variable into integer bins
+    (by rescaling and rounding) and then computes the whole MI matrix with the categorical mutual
+    information estimator. This avoids any Gaussian assumption on the continuous variables, at the
+    cost of a binning approximation.
+
+    Args:
+        data: The input data over which computing the MI matrix,
+            it must be in tabular form (i.e. a matrix).
+        is_categorical_mask: A boolean mask of the same length as the number of columns in `data`,
+            indicating if the column has to be considered categorical. The columns that are not
+            categorical (i.e. continuous) are the ones being discretized into bins.
+        bins: The number of bins into which each continuous variable is discretized.
+
+    Returns:
+        The mutual information matrix (main diagonal is 0).
+    """
+
+    is_categorical = torch.tensor(is_categorical_mask, dtype=torch.bool, device=data.device)
+    continuous_subset = torch.where(~is_categorical)[0]
+
+    x = data[:, continuous_subset].clone()
+    x = (x - x.min(dim=0, keepdim=True).values) * bins / x.max(dim=0, keepdim=True).values
+    x = x.round()
+
+    discretized_data = data.clone()
+    discretized_data[:, continuous_subset] = x
+
+    return _categorical_mutual_info(discretized_data.long()).float()

--- a/cirkit/templates/region_graph/algorithms/chow_liu.py
+++ b/cirkit/templates/region_graph/algorithms/chow_liu.py
@@ -1,3 +1,4 @@
+from warnings import warn
 import numpy as np
 import torch
 from scipy import sparse as sp
@@ -17,6 +18,7 @@ def ChowLiuTree(
     cat_bins: int | None = None,
     as_region_graph: bool = True,
     heter_cont_bins: int | None = None,
+    num_bins: int | None = None,
 ) -> np.ndarray | RegionGraph:
     """Learns a Chow-Liu Tree and returns it either as a
     list of predecessors (Bayesian net) or as region graph (HCLT).
@@ -50,6 +52,7 @@ def ChowLiuTree(
         heter_cont_bins (int | None): For heterogeneous (list) input, the number of bins used to
             discretize the continuous features so the whole MI matrix is estimated with the
             categorical estimator; if None, the mixed Gaussian/categorical estimator is used.
+        num_bins: Deprecated parameters, equivalent to cat_bins
 
     Returns:
         A Chow-Liu Tree, either a list of predecessors or as a region graph.
@@ -60,6 +63,12 @@ def ChowLiuTree(
     """
     assert data.ndim == 2
     assert root is None or -1 < root < data.size(-1)
+
+    if num_bins is not None:
+        warn("Argument `num_bins` will soon be removed, you should use `cat_bins` instead.")
+        assert cat_bins is None, "Cannot set both `num_bins` and `cat_bins`"
+        cat_bins = num_bins
+
     if isinstance(input_type, list):
         is_categorical_mask = [name == "categorical" for name in input_type]
         mutual_info = (
@@ -266,7 +275,9 @@ def _heterogeneous_mutual_info(
     # Compute mutual information for discrete variables
     if len(discrete_subset) > 1:
         mi_matrix[discrete_subset.unsqueeze(1), discrete_subset] = _categorical_mutual_info(
-            data=data[:, discrete_subset].long(), num_categories=None, chunk_size=None
+            data=data[:, discrete_subset].long(),
+            num_categories=None,
+            chunk_size=None,
         ).float()
 
     def gaussian_entropy(x: Tensor) -> Tensor:
@@ -316,7 +327,9 @@ def _heterogeneous_mutual_info(
             list(h_c.values()), dtype=torch.float32, device=data.device
         )
         entropy[discrete_subset] = torch.tensor(
-            [-(p.log() * p).sum() for p in p_d.values()], dtype=torch.float32, device=data.device
+            [-(p.log() * p).sum() for p in p_d.values()],
+            dtype=torch.float32,
+            device=data.device,
         )
         mi_matrix = 2 * mi_matrix / (entropy.unsqueeze(0) + entropy.unsqueeze(1))
 

--- a/cirkit/templates/region_graph/algorithms/chow_liu.py
+++ b/cirkit/templates/region_graph/algorithms/chow_liu.py
@@ -16,6 +16,7 @@ def ChowLiuTree(
     num_categories: int | None = None,
     num_bins: int | None = None,
     as_region_graph: bool = True,
+    bin_for_mi: int | None = None,
 ) -> np.ndarray | RegionGraph:
     """Learns a Chow-Liu Tree and returns it either as a
     list of predecessors (Bayesian net) or as region graph (HCLT).
@@ -46,6 +47,9 @@ def ChowLiuTree(
             which is useful for images.
         as_region_graph (Optional[bool]): True to returns a region graph,
             False to return a list of predecessors. Defaults to True.
+        bin_for_mi (int | None): For heterogeneous (list) input, the number of bins used to
+            discretize the continuous features so the whole MI matrix is estimated with the
+            categorical estimator; if None, the mixed Gaussian/categorical estimator is used.
 
     Returns:
         A Chow-Liu Tree, either a list of predecessors or as a region graph.
@@ -57,8 +61,13 @@ def ChowLiuTree(
     assert data.ndim == 2
     assert root is None or -1 < root < data.size(-1)
     if isinstance(input_type, list):
-        mutual_info = _heterogeneous_mutual_info(
-            data, is_categorical_mask=[name == "categorical" for name in input_type]
+        is_categorical_mask = [name == "categorical" for name in input_type]
+        mutual_info = (
+            _heterogeneous_mutual_info(data, is_categorical_mask=is_categorical_mask)
+            if bin_for_mi is None
+            else _heterogeneous_mutual_info_bin(
+                data, is_categorical_mask=is_categorical_mask, bins=bin_for_mi
+            )
         )
     elif input_type == "categorical":
         if num_bins is not None:
@@ -211,6 +220,23 @@ def _gaussian_mutual_info(
     mutual_info = -0.5 * torch.log1p(-squared_correlation)
 
     return mutual_info.fill_diagonal_(0)
+
+
+def _heterogeneous_mutual_info_bin(
+    data: Tensor, is_categorical_mask: list[bool], bins: int = 10
+) -> Tensor:
+
+    is_categorical = torch.tensor(is_categorical_mask, dtype=torch.bool, device=data.device)
+    continuous_subset = torch.where(~is_categorical)[0]
+
+    x = data[:, continuous_subset].clone()
+    x = (x - x.min(dim=0, keepdim=True).values) * bins / x.max(dim=0, keepdim=True).values
+    x = x.round()
+
+    discretized_data = data.clone()
+    discretized_data[:, continuous_subset] = x
+
+    return _categorical_mutual_info(discretized_data.long()).float()
 
 
 def _heterogeneous_mutual_info(

--- a/cirkit/templates/region_graph/algorithms/chow_liu.py
+++ b/cirkit/templates/region_graph/algorithms/chow_liu.py
@@ -21,12 +21,15 @@ def ChowLiuTree(
     list of predecessors (Bayesian net) or as region graph (HCLT).
 
     See:
-        - *Approximating discrete probability distributions with dependence trees* [🔗](https://ieeexplore.ieee.org/abstract/document/1054142)
+        - *Approximating discrete probability distributions with dependence trees*
+          [🔗](https://ieeexplore.ieee.org/abstract/document/1054142)
           CKCN Chow and Cong Liu.
           In IEEE transactions on Information Theory, 14(3):462–467, 1968b.
 
-        - *What is the Relationship between Tensor Factorizations and Circuits (and How Can We Exploit it)?* [🔗](https://openreview.net/forum?id=Y7dRmpGiHj)
-          Lorenzo Loconte and Antonio Mari and Gennaro Gala and Robert Peharz and Cassio de Campos and Erik Quaeghebeur and Gennaro Vessio and Antonio Vergari
+        - *What is the Relationship between Tensor Factorizations and Circuits (and How Can We
+          Exploit it)?* [🔗](https://openreview.net/forum?id=Y7dRmpGiHj)
+          Lorenzo Loconte and Antonio Mari and Gennaro Gala and Robert Peharz and Cassio de
+          Campos and Erik Quaeghebeur and Gennaro Vessio and Antonio Vergari
           In Transactions on Machine Learning Research, 2025.
 
     Args:
@@ -66,8 +69,7 @@ def ChowLiuTree(
             data.long(), num_categories=num_categories, chunk_size=chunk_size
         )
     elif input_type == "gaussian":
-        # todo: implement chunked computation
-        mutual_info = -0.5 * torch.log(1 - torch.corrcoef(data.t()) ** 2)
+        mutual_info = _gaussian_mutual_info(data, chunk_size=chunk_size)
     else:
         raise NotImplementedError(f"MI computation not implemented for {input_type} input units")
 
@@ -151,13 +153,74 @@ def _categorical_mutual_info(
     return (joints * (joints.log() - outers.log())).sum(dim=(2, 3)).fill_diagonal_(0)
 
 
+def _gaussian_mutual_info(
+    data: Tensor,
+    chunk_size: int | None = None,
+) -> Tensor:
+    """Computes the mutual information (MI) matrix assuming jointly Gaussian variables.
+
+    For a pair of jointly Gaussian variables the MI has the closed form
+    I(X_i, X_j) = -0.5 * log(1 - rho_ij ** 2), where rho_ij is their Pearson
+    correlation coefficient. The unnormalized covariance is accumulated over chunks
+    of samples, this reduces the centered-data scratch space from
+    O(n_samples * n_features) to O(chunk_size * n_features).
+
+    Args:
+        data (Tensor): The input data over which computing the MI matrix, it must be in
+            tabular form, i.e., a matrix of shape (num_samples, num_features).
+        chunk_size (int | None): Number of samples per chunk. If None, all samples are
+            processed at once.
+
+    Returns:
+        Tensor: The mutual information matrix, with main diagonal equal to 0.
+
+    Raises:
+        ValueError: If data is not a real floating-point matrix with at least two samples
+            and one feature, or if chunk_size is not a positive integer.
+    """
+    n_samples, n_features = data.size()
+
+    assert not torch.is_complex(data)
+    assert torch.is_floating_point(data)
+    assert n_samples > 1
+    assert n_features > 0
+
+    if chunk_size is None:
+        chunk_size = n_samples
+    elif not isinstance(chunk_size, int) or isinstance(chunk_size, bool) or chunk_size <= 0:
+        raise ValueError(f"Expected chunk_size to be a positive integer, but found {chunk_size}")
+
+    gaussian_correlation_epsilon = torch.finfo(data.dtype).eps
+    mean = data.mean(dim=0)
+    covariance = torch.zeros(n_features, n_features, dtype=data.dtype, device=data.device)
+
+    # Accumulate S = sum_n (x_n - mean)(x_n - mean)^T over sample chunks
+    for chunk in data.split(chunk_size):
+        centered = chunk - mean
+        covariance = covariance + centered.t() @ centered
+
+    variance = covariance.diagonal()
+    inv_std = torch.zeros_like(variance)
+    non_constant = variance > 0
+    inv_std[non_constant] = variance[non_constant].rsqrt()
+
+    # rho_ij = S_ij / sqrt(S_ii S_jj)
+    correlation = covariance.mul(inv_std.unsqueeze(1)).mul(inv_std.unsqueeze(0))
+    # I(X_i, X_j) = -0.5 * log(1 - rho_ij^2)
+    squared_correlation = correlation.square().clamp_max(1.0 - gaussian_correlation_epsilon)
+    mutual_info = -0.5 * torch.log1p(-squared_correlation)
+
+    return mutual_info.fill_diagonal_(0)
+
+
 def _heterogeneous_mutual_info(
     data: Tensor, is_categorical_mask: list[bool], normalize: bool = True
 ) -> Tensor:
     """Computes the mutual information (MI) matrix for heterogeneous data
     (both discrete/categorical data and continuous).
     The MI among continuous variables is computed as if they were a Multivariate Gaussian.
-    The MI among discrete variables is computed using the categorical mutual information defined above.
+    The MI among discrete variables is computed using the categorical mutual information
+    defined above.
     The MI between a continuous variable C and discrete variable D is computed using the formula:
         I(C, D) = H(C) - H(C | D)
     assuming gaussian distributions p(C|D) for continuous variables when conditioned on discrete
@@ -187,12 +250,9 @@ def _heterogeneous_mutual_info(
 
     # Compute mutual information for continuous variables as they were a Multivariate Gaussian
     if len(continuous_subset) > 1:
-        mi_matrix[continuous_subset.unsqueeze(1), continuous_subset] = (
-            -0.5
-            * torch.log(
-                1 - torch.corrcoef(data[:, continuous_subset].t()).fill_diagonal_(0) ** 2
-            ).float()
-        )
+        mi_matrix[continuous_subset.unsqueeze(1), continuous_subset] = _gaussian_mutual_info(
+            data[:, continuous_subset]
+        ).float()
 
     # Compute mutual information for discrete variables
     if len(discrete_subset) > 1:

--- a/tests/data_modalities/test_image_data.py
+++ b/tests/data_modalities/test_image_data.py
@@ -1,0 +1,120 @@
+import itertools
+
+import pytest
+import torch
+
+from cirkit.pipeline import compile
+from cirkit.symbolic.layers import (
+    BinomialLayer,
+    CategoricalLayer,
+    EmbeddingLayer,
+    GaussianLayer,
+)
+from cirkit.templates import utils
+from cirkit.templates.data_modalities import image_data
+
+REGION_GRAPHS = [
+    "quad-tree-2",
+    "quad-tree-4",
+    "quad-graph",
+    "random-binary-tree",
+    "poon-domingos",
+    "chow-liu-tree",
+    "linear-tree",
+]
+
+INPUT_LAYERS = ["categorical", "binomial", "embedding", "gaussian"]
+
+EXPECTED_LAYER_TYPE = {
+    "categorical": CategoricalLayer,
+    "binomial": BinomialLayer,
+    "embedding": EmbeddingLayer,
+    "gaussian": GaussianLayer,
+}
+
+
+def _make_image_data(input_layer: str, num_samples: int, num_variables: int) -> torch.Tensor:
+    if input_layer == "gaussian":
+        return torch.randn(num_samples, num_variables)
+    return torch.randint(0, 256, (num_samples, num_variables)).long()
+
+
+def _input_params(input_layer: str) -> dict | None:
+    """Ensure the Embedding layer encodes a proper distribution."""
+    if input_layer == "embedding":
+        return {"weight": utils.Parameterization(activation="softmax", initialization="normal")}
+    return None
+
+
+@pytest.mark.parametrize(
+    "region_graph,input_layer",
+    itertools.product(REGION_GRAPHS, INPUT_LAYERS),
+)
+def test_image_data_modality(region_graph: str, input_layer: str):
+    image_shape = (1, 3, 3)
+    num_variables = image_shape[0] * image_shape[1] * image_shape[2]
+    num_samples = 64
+    data = _make_image_data(input_layer, num_samples, num_variables)
+
+    symbolic_circuit = image_data(
+        image_shape,
+        region_graph=region_graph,
+        input_layer=input_layer,
+        num_input_units=2,
+        sum_product_layer="cp",
+        num_sum_units=2,
+        input_params=_input_params(input_layer),
+        data=data,
+        sum_weight_param=utils.Parameterization(activation="softmax", initialization="normal"),
+        use_mixing_weights=True,
+    )
+
+    assert len(symbolic_circuit.scope) == num_variables
+
+    expected_type = EXPECTED_LAYER_TYPE[input_layer]
+    for circuit_input_layer in symbolic_circuit.input_layers:
+        assert len(circuit_input_layer.scope) == 1
+        assert isinstance(
+            circuit_input_layer, expected_type
+        ), f"Expected {expected_type.__name__}, got {type(circuit_input_layer).__name__}"
+
+    # Check if the finite log-likelihoods has the expected shape
+    circuit = compile(symbolic_circuit)
+    ll = circuit(data)
+    assert ll.shape == (num_samples, 1, 1)
+    assert torch.isfinite(ll).all()
+
+
+@pytest.mark.parametrize(
+    "input_layer,num_bins,mi_chunk_size",
+    itertools.product(["categorical", "binomial", "embedding", "gaussian"], [None, 8], [None, 16]),
+)
+def test_image_data_chow_liu_tree_options(
+    input_layer: str, num_bins: int | None, mi_chunk_size: int | None
+):
+
+    image_shape = (1, 3, 3)
+    num_variables = image_shape[0] * image_shape[1] * image_shape[2]
+    num_samples = 128
+    data = _make_image_data(input_layer, num_samples, num_variables)
+
+    symbolic_circuit = image_data(
+        image_shape,
+        region_graph="chow-liu-tree",
+        input_layer=input_layer,
+        num_input_units=2,
+        sum_product_layer="cp",
+        num_sum_units=2,
+        input_params=_input_params(input_layer),
+        data=data,
+        num_bins=num_bins,
+        mi_chunk_size=mi_chunk_size,
+        sum_weight_param=utils.Parameterization(activation="softmax", initialization="normal"),
+    )
+
+    # Check if the finite log-likelihoods has the expected shape
+    assert len(symbolic_circuit.scope) == num_variables
+    circuit = compile(symbolic_circuit)
+    ll = circuit(data)
+    assert ll.shape == (num_samples, 1, 1)
+    assert torch.isfinite(ll).all()

--- a/tests/data_modalities/test_image_data.py
+++ b/tests/data_modalities/test_image_data.py
@@ -112,9 +112,8 @@ def test_image_data_chow_liu_tree_options(
         sum_weight_param=utils.Parameterization(activation="softmax", initialization="normal"),
     )
 
-    # Check if the finite log-likelihoods has the expected shape
     assert len(symbolic_circuit.scope) == num_variables
     circuit = compile(symbolic_circuit)
-    ll = circuit(data)
-    assert ll.shape == (num_samples, 1, 1)
-    assert torch.isfinite(ll).all()
+    output = circuit(data)
+    assert output.shape == (num_samples, 1, 1)
+    assert torch.isfinite(output).all()

--- a/tests/templates/region_graph/test_algorithms.py
+++ b/tests/templates/region_graph/test_algorithms.py
@@ -2,14 +2,17 @@ import itertools
 
 import numpy as np
 import pytest
+import torch
 
 from cirkit.templates.region_graph import (
+    ChowLiuTree,
     FullyFactorized,
     LinearTree,
     PoonDomingos,
     QuadGraph,
     QuadTree,
     RandomBinaryTree,
+    RegionGraph,
     RegionNode,
 )
 from cirkit.utils.scope import Scope
@@ -144,3 +147,53 @@ def test_rg_algorithm_poon_domingos(
         assert not rg.is_structured_decomposable
     # TODO: how to test the PoonDomingos region graph?
     check_region_graph_save_load(rg)
+
+
+def _chow_liu_data(input_type: str, num_variables: int, num_samples: int) -> "torch.Tensor":
+    torch.manual_seed(42)
+    if input_type == "categorical":
+        data = torch.randint(0, 5, (num_samples, num_variables))
+        data[:, 1] = torch.where(torch.rand(num_samples) < 0.8, data[:, 0], data[:, 1])
+    elif input_type == "gaussian":
+        data = torch.randn(num_samples, num_variables)
+        data[:, 1] += 0.7 * data[:, 0]
+    else:  # heterogeneous: half continuous, half discrete columns
+        num_continuous = num_variables // 2
+        continuous = torch.randn(num_samples, num_continuous)
+        continuous[:, 1 % num_continuous] += 0.7 * continuous[:, 0]
+        discrete = torch.randint(0, 4, (num_samples, num_variables - num_continuous)).float()
+        data = torch.cat([continuous, discrete], dim=1)
+    return data
+
+
+@pytest.mark.parametrize(
+    "input_type,chunk_size",
+    itertools.product(["categorical", "gaussian", "heterogeneous"], [None, 256]),
+)
+def test_rg_algorithm_chow_liu_tree(input_type: str, chunk_size: int | None):
+    num_variables = 6
+    num_samples = 2000
+    data = _chow_liu_data(input_type, num_variables, num_samples)
+    if input_type == "heterogeneous":
+        num_continuous = num_variables // 2
+        rg_input_type: str | list[str] = ["gaussian"] * num_continuous + ["categorical"] * (
+            num_variables - num_continuous
+        )
+    else:
+        rg_input_type = input_type
+
+    rg = ChowLiuTree(
+        data=data, input_type=rg_input_type, chunk_size=chunk_size, as_region_graph=True
+    )
+
+    assert isinstance(rg, RegionGraph)
+    root: RegionNode
+    (root,) = list(rg.outputs)
+    assert isinstance(root, RegionNode)
+    assert root.scope == Scope(range(num_variables))
+    assert rg.is_structured_decomposable
+    assert not rg.is_omni_compatible
+    assert len(list(rg.inputs)) == num_variables
+    assert all(len(rgn.scope) == 1 for rgn in rg.inputs)
+    assert {variable for rgn in rg.inputs for variable in rgn.scope} == set(range(num_variables))
+    assert all(len(rg.partition_inputs(ptn)) >= 2 for ptn in rg.partition_nodes)

--- a/tests/templates/region_graph/test_algorithms.py
+++ b/tests/templates/region_graph/test_algorithms.py
@@ -151,7 +151,7 @@ def test_rg_algorithm_poon_domingos(
 
 def _chow_liu_tree_data(
     input_type: str, parents: list[int], is_categorical: list[bool], num_samples: int
-):
+) -> torch.Tensor:
     torch.manual_seed(42)
     coupling = 0.9
     num_categories = 4

--- a/tests/templates/region_graph/test_algorithms.py
+++ b/tests/templates/region_graph/test_algorithms.py
@@ -149,43 +149,80 @@ def test_rg_algorithm_poon_domingos(
     check_region_graph_save_load(rg)
 
 
-def _chow_liu_data(input_type: str, num_variables: int, num_samples: int) -> "torch.Tensor":
+def _chow_liu_tree_data(
+    input_type: str, parents: list[int], is_categorical: list[bool], num_samples: int
+):
     torch.manual_seed(42)
+    coupling = 0.9
+    num_categories = 4
+    num_variables = len(parents)
     if input_type == "categorical":
-        data = torch.randint(0, 5, (num_samples, num_variables))
-        data[:, 1] = torch.where(torch.rand(num_samples) < 0.8, data[:, 0], data[:, 1])
-    elif input_type == "gaussian":
-        data = torch.randn(num_samples, num_variables)
-        data[:, 1] += 0.7 * data[:, 0]
-    else:  # heterogeneous: half continuous, half discrete columns
-        num_continuous = num_variables // 2
-        continuous = torch.randn(num_samples, num_continuous)
-        continuous[:, 1 % num_continuous] += 0.7 * continuous[:, 0]
-        discrete = torch.randint(0, 4, (num_samples, num_variables - num_continuous)).float()
-        data = torch.cat([continuous, discrete], dim=1)
-    return data
+        columns = [torch.randint(0, num_categories, (num_samples,))]
+        for parent in parents[1:]:
+            noise = torch.randint(0, num_categories, (num_samples,))
+            # child = parent with coupling probability, else child = random noise
+            mask = torch.rand(num_samples) < coupling
+            columns.append(torch.where(mask, columns[parent], noise))
+        return torch.stack(columns, dim=1)
+    latent = [torch.randn(num_samples)]
+    for parent in parents[1:]:
+        noise = torch.randn(num_samples)
+        latent.append(coupling * latent[parent] + (1 - coupling**2) ** 0.5 * noise)
+    if input_type == "gaussian":
+        return torch.stack(latent, dim=1)
+    # heterogeneous data
+    probs = torch.arange(1, num_categories, dtype=torch.float32) / num_categories
+    cut_points = torch.distributions.Normal(0.0, 1.0).icdf(probs)
+    columns = [
+        torch.bucketize(latent[v], cut_points).float() if is_categorical[v] else latent[v]
+        for v in range(num_variables)
+    ]
+    return torch.stack(columns, dim=1)
 
 
 @pytest.mark.parametrize(
-    "input_type,chunk_size",
-    itertools.product(["categorical", "gaussian", "heterogeneous"], [None, 256]),
+    "input_type,chunk_size,bin_for_mi",
+    [
+        (input_type, chunk_size, bin_for_mi)
+        for input_type in ["categorical", "gaussian", "heterogeneous"]
+        for chunk_size in [None, 256]
+        for bin_for_mi in ([None, 10] if input_type == "heterogeneous" else [None])
+    ],
 )
-def test_rg_algorithm_chow_liu_tree(input_type: str, chunk_size: int | None):
-    num_variables = 6
-    num_samples = 2000
-    data = _chow_liu_data(input_type, num_variables, num_samples)
+def test_rg_algorithm_chow_liu_tree(
+    input_type: str, chunk_size: int | None, bin_for_mi: int | None
+):
+    # parent index for each variable, -1 when the variable is the root
+    parents = [-1, 0, 0, 1, 1, 2]
+    # for heterogeneous input_type only
+    is_categorical = [False, False, True, False, True, True]
+    num_samples = 8000
+    num_variables = len(parents)
+    data = _chow_liu_tree_data(input_type, parents, is_categorical, num_samples)
     if input_type == "heterogeneous":
-        num_continuous = num_variables // 2
-        rg_input_type: str | list[str] = ["gaussian"] * num_continuous + ["categorical"] * (
-            num_variables - num_continuous
-        )
+        rg_input_type = ["categorical" if c else "gaussian" for c in is_categorical]
     else:
         rg_input_type = input_type
 
-    rg = ChowLiuTree(
-        data=data, input_type=rg_input_type, chunk_size=chunk_size, as_region_graph=True
+    tree = ChowLiuTree(
+        data=data,
+        input_type=rg_input_type,
+        root=0,
+        chunk_size=chunk_size,
+        bin_for_mi=bin_for_mi,
+        as_region_graph=False,
     )
+    assert tree.shape == (num_variables,)
+    assert np.array_equal(tree, np.asarray(parents))
 
+    rg = ChowLiuTree(
+        data=data,
+        input_type=rg_input_type,
+        root=0,
+        chunk_size=chunk_size,
+        bin_for_mi=bin_for_mi,
+        as_region_graph=True,
+    )
     assert isinstance(rg, RegionGraph)
     root: RegionNode
     (root,) = list(rg.outputs)

--- a/tests/templates/region_graph/test_algorithms.py
+++ b/tests/templates/region_graph/test_algorithms.py
@@ -181,16 +181,16 @@ def _chow_liu_tree_data(
 
 
 @pytest.mark.parametrize(
-    "input_type,chunk_size,bin_for_mi",
+    "input_type,chunk_size,heter_cont_bins",
     [
-        (input_type, chunk_size, bin_for_mi)
+        (input_type, chunk_size, heter_cont_bins)
         for input_type in ["categorical", "gaussian", "heterogeneous"]
         for chunk_size in [None, 256]
-        for bin_for_mi in ([None, 10] if input_type == "heterogeneous" else [None])
+        for heter_cont_bins in ([None, 10] if input_type == "heterogeneous" else [None])
     ],
 )
 def test_rg_algorithm_chow_liu_tree(
-    input_type: str, chunk_size: int | None, bin_for_mi: int | None
+    input_type: str, chunk_size: int | None, heter_cont_bins: int | None
 ):
     # parent index for each variable, -1 when the variable is the root
     parents = [-1, 0, 0, 1, 1, 2]
@@ -209,7 +209,7 @@ def test_rg_algorithm_chow_liu_tree(
         input_type=rg_input_type,
         root=0,
         chunk_size=chunk_size,
-        bin_for_mi=bin_for_mi,
+        heter_cont_bins=heter_cont_bins,
         as_region_graph=False,
     )
     assert tree.shape == (num_variables,)
@@ -220,7 +220,7 @@ def test_rg_algorithm_chow_liu_tree(
         input_type=rg_input_type,
         root=0,
         chunk_size=chunk_size,
-        bin_for_mi=bin_for_mi,
+        heter_cont_bins=heter_cont_bins,
         as_region_graph=True,
     )
     assert isinstance(rg, RegionGraph)


### PR DESCRIPTION
This PR does: 
1. enabled the use of CLT `chow-liu-tree` and HMM `linear-tree` region graphs in constructing region graph from image data
2. added chunked mutual information (over data axis) for Chow-Liu Tree with Gaussian inputs 
3. Corresponding tests for both 

Notice that:  
1. In `chow_liu.py`, in chunked mutual information for CLT, the implementation in Monarch [Circuit](https://github.com/wangben88/MonarchCircuits/blob/master/monarch_juice/structures/HCLTMonarch.py) chunked over the feature axis, while our existing categorical case ( `_categorical_mutual_info` ) chunked over the data axis. For categorical inputs, it is more memory efficient to chunk over the feature axis (O(feature*samples) vs O(feature^2 * categories^2)); but for the gaussian inputs, it is bette to chunk over the data axis (O(feature*samples)) difference. However, the images we use won't be extremely large so both options could fit into memory. So for consistency, chunked mutual information along the data axis is implemented for Gaussian inputs. 
2. In `data_modalities.py`, note that the existing `LinearTree` region graph is just HMM region graph, I simply flattens the image to linear order since other [code base](https://github.com/Tractables/pyjuice/blob/09e20a5539c2602d6ffee7b9119cb083a711a4d0/src/pyjuice/structures/hmm.py) does the same 