### PR TITLE
fix mixed type in scopes

### DIFF
--- a/cirkit/backend/torch/rules/layers.py
+++ b/cirkit/backend/torch/rules/layers.py
@@ -37,9 +37,7 @@ if TYPE_CHECKING:
     from cirkit.backend.torch.compiler import TorchCompiler
 
 
-def compile_embedding_layer(
-    compiler: "TorchCompiler", sl: EmbeddingLayer
-) -> TorchEmbeddingLayer:
+def compile_embedding_layer(compiler: "TorchCompiler", sl: EmbeddingLayer) -> TorchEmbeddingLayer:
     weight = compiler.compile_parameter(sl.weight)
     return TorchEmbeddingLayer(
         torch.tensor(tuple(sl.scope)),
@@ -71,9 +69,7 @@ def compile_categorical_layer(
     )
 
 
-def compile_binomial_layer(
-    compiler: "TorchCompiler", sl: BinomialLayer
-) -> TorchBinomialLayer:
+def compile_binomial_layer(compiler: "TorchCompiler", sl: BinomialLayer) -> TorchBinomialLayer:
     if sl.logits is None:
         assert sl.probs is not None
         probs = compiler.compile_parameter(sl.probs)
@@ -92,9 +88,7 @@ def compile_binomial_layer(
     )
 
 
-def compile_gaussian_layer(
-    compiler: "TorchCompiler", sl: GaussianLayer
-) -> TorchGaussianLayer:
+def compile_gaussian_layer(compiler: "TorchCompiler", sl: GaussianLayer) -> TorchGaussianLayer:
     mean = compiler.compile_parameter(sl.mean)
     stddev = compiler.compile_parameter(sl.stddev)
     if sl.log_partition is not None:
@@ -124,20 +118,12 @@ def compile_polynomial_layer(
     )
 
 
-def compile_hadamard_layer(
-    compiler: "TorchCompiler", sl: HadamardLayer
-) -> TorchHadamardLayer:
-    return TorchHadamardLayer(
-        sl.num_input_units, arity=sl.arity, semiring=compiler.semiring
-    )
+def compile_hadamard_layer(compiler: "TorchCompiler", sl: HadamardLayer) -> TorchHadamardLayer:
+    return TorchHadamardLayer(sl.num_input_units, arity=sl.arity, semiring=compiler.semiring)
 
 
-def compile_kronecker_layer(
-    compiler: "TorchCompiler", sl: KroneckerLayer
-) -> TorchKroneckerLayer:
-    return TorchKroneckerLayer(
-        sl.num_input_units, arity=sl.arity, semiring=compiler.semiring
-    )
+def compile_kronecker_layer(compiler: "TorchCompiler", sl: KroneckerLayer) -> TorchKroneckerLayer:
+    return TorchKroneckerLayer(sl.num_input_units, arity=sl.arity, semiring=compiler.semiring)
 
 
 def compile_sum_layer(compiler: "TorchCompiler", sl: SumLayer) -> TorchSumLayer:
@@ -163,9 +149,7 @@ def compile_constant_value_layer(
     )
 
 
-def compile_evidence_layer(
-    compiler: "TorchCompiler", sl: EvidenceLayer
-) -> TorchEvidenceLayer:
+def compile_evidence_layer(compiler: "TorchCompiler", sl: EvidenceLayer) -> TorchEvidenceLayer:
     layer = compiler.compile_layer(sl.layer)
     observation = compiler.compile_parameter(sl.observation)
     return TorchEvidenceLayer(
@@ -175,9 +159,7 @@ def compile_evidence_layer(
     )
 
 
-DEFAULT_LAYER_COMPILATION_RULES: dict[
-    LayerCompilationSign, Callable[..., TorchLayer]
-] = {
+DEFAULT_LAYER_COMPILATION_RULES: dict[LayerCompilationSign, Callable[..., TorchLayer]] = {
     EmbeddingLayer: compile_embedding_layer,
     CategoricalLayer: compile_categorical_layer,
     BinomialLayer: compile_binomial_layer,

--- a/cirkit/templates/region_graph/algorithms/utils.py
+++ b/cirkit/templates/region_graph/algorithms/utils.py
@@ -91,7 +91,7 @@ def tree2rg(tree: np.ndarray) -> RegionGraph:
             else:
                 p_scope = Scope([v]) | prev_partition.scope
                 partitions[prev_v] = PartitionNode(p_scope)
-            cur_v, prev_v = prev_v, tree[cur_v]
+            cur_v, prev_v = prev_v, int(tree[cur_v])
 
     for part_node in partitions:
         if part_node is not None:


### PR DESCRIPTION
Fixed a weird problem when using CLTs, the scope was often a mixed set of int and numpy.int23 which was (1) weird when debugging, (2) causes troubles when plotting the RG and (3) causes the `.dump` method of RG to dump a mixed list of int and special types which is bad for serialization.